### PR TITLE
fix pt rules for numeral

### DIFF
--- a/Duckling/Numeral/PT/Rules.hs
+++ b/Duckling/Numeral/PT/Rules.hs
@@ -8,14 +8,19 @@
 
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE NoRebindableSyntax #-}
 
 module Duckling.Numeral.PT.Rules
   ( rules
   ) where
 
+import Control.Applicative ((<|>))
+import Data.HashMap.Strict (HashMap)
 import Data.Maybe
 import Data.String
+import Data.Text (Text)
 import Prelude
+import qualified Data.HashMap.Strict as HashMap
 import qualified Data.Text as Text
 
 import Duckling.Dimensions.Types
@@ -25,189 +30,303 @@ import Duckling.Regex.Types
 import Duckling.Types
 import qualified Duckling.Numeral.Types as TNumeral
 
-ruleNumeralsPrefixWithNegativeOrMinus :: Rule
-ruleNumeralsPrefixWithNegativeOrMinus = Rule
-  { name = "numbers prefix with -, negative or minus"
+ruleIntegers :: Rule
+ruleIntegers = Rule
+  { name = "integer (numeric)"
   , pattern =
-    [ regex "-|menos"
-    , dimension Numeral
+    [ regex "(\\d{1,18})"
+    ]
+  , prod = \tokens -> case tokens of
+      (Token RegexMatch (GroupMatch (match:_)):_) ->
+        toInteger <$> parseInt match >>= integer
+      _ -> Nothing
+  }
+
+ruleDozen :: Rule
+ruleDozen = Rule
+  { name = "a dozen of"
+  , pattern =
+    [ regex "(uma )?d(u|ú)zia?( de)?"
+    ]
+  , prod = \_ -> integer 12 >>= withMultipliable >>= notOkForAnyTime
+  }
+
+zeroNineteenMap :: HashMap Text Integer
+zeroNineteenMap = HashMap.fromList
+  [ ( "zero"        , 0 )
+  , ( "um"          , 1 )
+  , ( "dois"        , 2 )
+  , ( "tres"        , 3 )
+  , ( "quatro"      , 4 )
+  , ( "cinco"       , 5 )
+  , ( "seis"        , 6 )
+  , ( "sete"        , 7 )
+  , ( "oito"        , 8 )
+  , ( "nove"        , 9 )
+  , ( "dez"         , 10 )
+  , ( "onze"        , 11 )
+  , ( "doze"        , 12 )
+  , ( "treze"       , 13 )
+  , ( "quatorze"    , 14 )
+  , ( "quinze"      , 15 )
+  , ( "dezesseis"   , 16 )
+  , ( "dezessete"   , 17 )
+  , ( "dezoito"     , 18 )
+  , ( "dezenove"    , 19 )
+  ]
+
+informalMap :: HashMap Text Integer
+informalMap = HashMap.fromList
+  [ ( "um par"      , 2 )
+  , ( "um par de"   , 2 )
+  , ( "par"         , 2 )
+  , ( "pares"       , 2 )
+  , ( "par de"      , 2 )
+  , ( "pares de"    , 2 )
+  , ( "um pouco"    , 3 )
+  , ( "pouco"       , 3 )
+  ]
+
+ruleToNineteen :: Rule
+ruleToNineteen = Rule
+  { name = "integer (0..19)"
+  -- e.g. fourteen must be before four, otherwise four will always shadow fourteen
+  , pattern =
+    [ regex "(zero|um|(dois|duas)|(um |uma )?(par)(es)?( de)?|tr(e|ê)s|(um )?pouco|quatorze|quatro|quinze|cinco|dezesseis|seis|dezessete|sete|dezoito|oito|dezenove|nove|dez|onze|doze|treze)"
+    ]
+  , prod = \tokens -> case tokens of
+      (Token RegexMatch (GroupMatch (match:_)):_) ->
+        let x = Text.toLower match in
+        (HashMap.lookup x zeroNineteenMap >>= integer) <|>
+        (HashMap.lookup x informalMap >>= integer >>= notOkForAnyTime)
+      _ -> Nothing
+  }
+
+tensMap :: HashMap Text Integer
+tensMap = HashMap.fromList
+  [ ( "vinte"     , 20 )
+  , ( "trinta"    , 30 )
+  , ( "quarenta"  , 40 )
+  , ( "cinquenta" , 50 )
+  , ( "sessenta"  , 60 )
+  , ( "setenta"   , 70 )
+  , ( "oitenta"   , 80 )
+  , ( "noventa"   , 90 )
+  ]
+
+ruleTens :: Rule
+ruleTens = Rule
+  { name = "integer (20..90)"
+  , pattern =
+    [ regex "(vinte|trinta|quarenta|cinquenta|sessenta|setenta|oitenta|noventa)"
+    ]
+  , prod = \tokens -> case tokens of
+      (Token RegexMatch (GroupMatch (match:_)):_) ->
+        HashMap.lookup (Text.toLower match) tensMap >>= integer
+      _ -> Nothing
+  }
+
+centsMap :: HashMap Text Integer
+centsMap = HashMap.fromList
+  [ ( "cem"           , 100 )
+  , ( "cento"         , 100 )
+  , ( "duzentos"      , 200 )
+  , ( "trezentos"     , 300 )
+  , ( "quatrocentos"  , 400 )
+  , ( "quinhetos"     , 500 )
+  , ( "seiscentos"    , 600 )
+  , ( "setecentos"    , 700 )
+  , ( "oitocentos"    , 800 )
+  , ( "novecentos"    , 900 )
+  ]
+
+ruleCent :: Rule
+ruleCent = Rule
+  { name = "integer (100..900)"
+  , pattern =
+    [ regex "(cem|cento|duzentos|trezentos|quatrocentos|quinhetos|seiscentos|setecentos|oitocentos|novecentos)"
+    ]
+  , prod = \tokens -> case tokens of
+      (Token RegexMatch (GroupMatch (match:_)):_) ->
+        HashMap.lookup (Text.toLower match) centsMap >>= integer
+      _ -> Nothing
+  }
+
+rulePowersOfTen :: Rule
+rulePowersOfTen = Rule
+  { name = "powers of tens"
+  , pattern =
+    [ regex "(milhao|milhão|milhões|milhoes|bilhao|bilhão|bilhões|bilhoes|mil)"
+    ]
+  , prod = \tokens -> case tokens of
+      (Token RegexMatch (GroupMatch (match:_)):_) -> case Text.toLower match of
+        "milhao"   -> double 1e6 >>= withGrain 6 >>= withMultipliable
+        "milhão"   -> double 1e6 >>= withGrain 6 >>= withMultipliable
+        "milhões"  -> double 1e6 >>= withGrain 6 >>= withMultipliable
+        "milhoes"  -> double 1e6 >>= withGrain 6 >>= withMultipliable
+        "bilhao"   -> double 1e9 >>= withGrain 9 >>= withMultipliable
+        "bilhão"   -> double 1e9 >>= withGrain 9 >>= withMultipliable
+        "bilhões"  -> double 1e9 >>= withGrain 9 >>= withMultipliable
+        "bilhoes"  -> double 1e9 >>= withGrain 9 >>= withMultipliable
+        "mil"      -> double 1e3 >>= withGrain 3 >>= withMultipliable
+        _          -> Nothing
+      _ -> Nothing
+  }
+
+ruleCompositeTens :: Rule
+ruleCompositeTens = Rule
+  { name = "integer 21..99"
+  , pattern =
+    [ oneOf [20,30..90]
+    , numberBetween 1 10
+    ]
+  , prod = \tokens -> case tokens of
+      (Token Numeral (NumeralData {TNumeral.value = tens}):
+       Token Numeral (NumeralData {TNumeral.value = units}):
+       _) -> double $ tens + units
+      _ -> Nothing
+  }
+
+ruleCompositeCents :: Rule
+ruleCompositeCents = Rule
+  { name = "integer 100..999"
+  , pattern =
+    [ oneOf [100, 200..900]
+    , numberBetween 1 100
+    ]
+  , prod = \tokens -> case tokens of
+      (Token Numeral (NumeralData {TNumeral.value = tens}):
+       Token Numeral (NumeralData {TNumeral.value = units}):
+       _) -> double $ tens + units
+      _ -> Nothing
+  }
+
+ruleSkipHundreds :: Rule
+ruleSkipHundreds = Rule
+  { name = "one twenty two"
+  , pattern =
+    [ numberBetween 1 10
+    , numberBetween 10 100
+    ]
+  , prod = \tokens -> case tokens of
+      (Token Numeral (NumeralData {TNumeral.value = hundreds}):
+       Token Numeral (NumeralData {TNumeral.value = rest}):
+       _) -> double $ hundreds*100 + rest
+      _ -> Nothing
+  }
+
+ruleDotSpelledOut :: Rule
+ruleDotSpelledOut = Rule
+  { name = "one point 2"
+  , pattern =
+    [ dimension Numeral
+    , regex "point|dot"
+    , numberWith TNumeral.grain isNothing
+    ]
+  , prod = \tokens -> case tokens of
+      (Token Numeral nd1:_:Token Numeral nd2:_) ->
+        double $ TNumeral.value nd1 + decimalsToDouble (TNumeral.value nd2)
+      _ -> Nothing
+  }
+
+ruleLeadingDotSpelledOut :: Rule
+ruleLeadingDotSpelledOut = Rule
+  { name = "point 77"
+  , pattern =
+    [ regex "ponto"
+    , numberWith TNumeral.grain isNothing
+    ]
+  , prod = \tokens -> case tokens of
+      (_:Token Numeral nd:_) -> double . decimalsToDouble $ TNumeral.value nd
+      _ -> Nothing
+  }
+
+ruleDecimals :: Rule
+ruleDecimals = Rule
+  { name = "decimal number"
+  , pattern =
+    [ regex "(\\d*\\.\\d+)"
+    ]
+  , prod = \tokens -> case tokens of
+      (Token RegexMatch (GroupMatch (match:_)):_) -> parseDecimal True match
+      _ -> Nothing
+  }
+
+ruleFractions :: Rule
+ruleFractions = Rule
+  { name = "fractional number"
+  , pattern =
+    [ regex "(\\d+)/(\\d+)"
+    ]
+  , prod = \tokens -> case tokens of
+      (Token RegexMatch (GroupMatch (numerator:denominator:_)):_) -> do
+        n <- parseDecimal False numerator
+        d <- parseDecimal False denominator
+        divide n d
+      _ -> Nothing
+  }
+
+ruleCommas :: Rule
+ruleCommas = Rule
+  { name = "comma-separated numbers"
+  , pattern =
+    [ regex "(\\d+(,\\d\\d\\d)+(\\.\\d+)?)"
+    ]
+  , prod = \tokens -> case tokens of
+      (Token RegexMatch (GroupMatch (match:_)):_) ->
+        parseDouble (Text.replace "," Text.empty match) >>= double
+      _ -> Nothing
+  }
+
+ruleSuffixes :: Rule
+ruleSuffixes = Rule
+  { name = "suffixes (K,M,G))"
+  , pattern =
+    [ dimension Numeral
+    , regex "(k|m|g)(?=[\\W$€¢£]|$)"
+    ]
+  , prod = \tokens -> case tokens of
+      (Token Numeral nd : Token RegexMatch (GroupMatch (match : _)):_) -> do
+        x <- case Text.toLower match of
+          "k" -> Just 1e3
+          "m" -> Just 1e6
+          "g" -> Just 1e9
+          _ -> Nothing
+        double $ TNumeral.value nd * x
+      _ -> Nothing
+  }
+
+ruleNegative :: Rule
+ruleNegative = Rule
+  { name = "negative numbers"
+  , pattern =
+    [ regex "(-|menos|negativo)(?!\\s*-)"
+    , numberWith TNumeral.value (>0)
     ]
   , prod = \tokens -> case tokens of
       (_:Token Numeral nd:_) -> double (TNumeral.value nd * (-1))
       _ -> Nothing
   }
 
-ruleIntegerNumeric :: Rule
-ruleIntegerNumeric = Rule
-  { name = "integer (numeric)"
+ruleSum :: Rule
+ruleSum = Rule
+  { name = "intersect 2 numbers"
   , pattern =
-    [ regex "(\\d{1,18})"
+    [ numberWith (fromMaybe 0 . TNumeral.grain) (>1)
+    , numberWith TNumeral.multipliable not
     ]
   , prod = \tokens -> case tokens of
-      (Token RegexMatch (GroupMatch (match:_)):_) -> do
-        v <- parseInt match
-        integer $ toInteger v
+      (Token Numeral (NumeralData {TNumeral.value = val1, TNumeral.grain = Just g}):
+       Token Numeral (NumeralData {TNumeral.value = val2}):
+       _) | (10 ** fromIntegral g) > val2 -> double $ val1 + val2
       _ -> Nothing
   }
 
-ruleDecimalWithThousandsSeparator :: Rule
-ruleDecimalWithThousandsSeparator = Rule
-  { name = "decimal with thousands separator"
-  , pattern =
-    [ regex "(\\d+(\\.\\d\\d\\d)+,\\d+)"
-    ]
-  , prod = \tokens -> case tokens of
-      (Token RegexMatch (GroupMatch (match:_)):
-       _) -> let fmt = Text.replace "," "." $ Text.replace "." Text.empty match
-        in parseDouble fmt >>= double
-      _ -> Nothing
-  }
-
-ruleDecimalNumeral :: Rule
-ruleDecimalNumeral = Rule
-  { name = "decimal number"
-  , pattern =
-    [ regex "(\\d*,\\d+)"
-    ]
-  , prod = \tokens -> case tokens of
-      (Token RegexMatch (GroupMatch (match:_)):
-       _) -> parseDecimal False match
-      _ -> Nothing
-  }
-
-ruleNumeral2 :: Rule
-ruleNumeral2 = Rule
-  { name = "number (20..90)"
-  , pattern =
-    [ regex "(vinte|trinta|quarenta|cincoenta|cinq(ü)enta|cinquenta|sessenta|setenta|oitenta|noventa)"
-    ]
-  , prod = \tokens -> case tokens of
-      (Token RegexMatch (GroupMatch (match:_)):_) -> case Text.toLower match of
-        "vinte" -> integer 20
-        "trinta" -> integer 30
-        "quarenta" -> integer 40
-        "cinq\252enta" -> integer 50
-        "cincoenta" -> integer 50
-        "cinquenta" -> integer 50
-        "sessenta" -> integer 60
-        "setenta" -> integer 70
-        "oitenta" -> integer 80
-        "noventa" -> integer 90
-        _ -> Nothing
-      _ -> Nothing
-  }
-
-ruleNumeral :: Rule
-ruleNumeral = Rule
-  { name = "number (0..15)"
-  , pattern =
-    [ regex "(zero|uma?|d(oi|ua)s|tr(ê|e)s|quatro|cinco|seis|sete|oito|nove|dez|onze|doze|treze|(ca|qua)torze|quinze)"
-    ]
-  , prod = \tokens -> case tokens of
-      (Token RegexMatch (GroupMatch (match:_)):_) -> case Text.toLower match of
-        "zero" -> integer 0
-        "uma" -> integer 1
-        "um" -> integer 1
-        "dois" -> integer 2
-        "duas" -> integer 2
-        "três" -> integer 3
-        "tres" -> integer 3
-        "quatro" -> integer 4
-        "cinco" -> integer 5
-        "seis" -> integer 6
-        "sete" -> integer 7
-        "oito" -> integer 8
-        "nove" -> integer 9
-        "dez" -> integer 10
-        "onze" -> integer 11
-        "doze" -> integer 12
-        "treze" -> integer 13
-        "catorze" -> integer 14
-        "quatorze" -> integer 14
-        "quinze" -> integer 15
-        _ -> Nothing
-      _ -> Nothing
-  }
-
-ruleNumeral5 :: Rule
-ruleNumeral5 = Rule
-  { name = "number (16..19)"
-  , pattern =
-    [ regex "(dez[ea]sseis|dez[ea]ssete|dezoito|dez[ea]nove)"
-    ]
-  , prod = \tokens -> case tokens of
-      (Token RegexMatch (GroupMatch (match:_)):_) -> case Text.toLower match of
-        "dezesseis" -> integer 16
-        "dezasseis" -> integer 16
-        "dezessete" -> integer 17
-        "dezassete" -> integer 17
-        "dezoito" -> integer 18
-        "dezenove" -> integer 19
-        "dezanove" -> integer 19
-        _ -> Nothing
-      _ -> Nothing
-  }
-
-ruleNumeral3 :: Rule
-ruleNumeral3 = Rule
-  { name = "number (16..19)"
-  , pattern =
-    [ numberWith TNumeral.value (== 10)
-    , regex "e"
-    , numberBetween 6 10
-    ]
-  , prod = \tokens -> case tokens of
-      (_:Token Numeral (NumeralData {TNumeral.value = v}):_) -> double $ 10 + v
-      _ -> Nothing
-  }
-
-ruleNumeralsSuffixesKMG :: Rule
-ruleNumeralsSuffixesKMG = Rule
-  { name = "numbers suffixes (K, M, G)"
-  , pattern =
-    [ dimension Numeral
-    , regex "([kmg])(?=[\\W\\$€]|$)"
-    ]
-  , prod = \tokens -> case tokens of
-      (Token Numeral (NumeralData {TNumeral.value = v}):
-       Token RegexMatch (GroupMatch (match:_)):
-       _) -> case Text.toLower match of
-         "k" -> double $ v * 1e3
-         "m" -> double $ v * 1e6
-         "g" -> double $ v * 1e9
-         _   -> Nothing
-      _ -> Nothing
-  }
-
-ruleNumeral6 :: Rule
-ruleNumeral6 = Rule
-  { name = "number 100..1000 "
-  , pattern =
-    [
-      regex "(cem|cento|duzentos|trezentos|quatrocentos|quinhentos|seiscentos|setecentos|oitocentos|novecentos|mil)"
-    ]
-  , prod = \tokens -> case tokens of
-      (Token RegexMatch (GroupMatch (match:_)):_) -> case Text.toLower match of
-        "cento" -> integer 100
-        "cem" -> integer 100
-        "duzentos" -> integer 200
-        "trezentos" -> integer 300
-        "quatrocentos" -> integer 400
-        "quinhentos" -> integer 500
-        "seiscentos" -> integer 600
-        "setecentos" -> integer 700
-        "oitocentos" -> integer 800
-        "novecentos" -> integer 900
-        "mil" -> integer 1000
-        _ -> Nothing
-      _ -> Nothing
-  }
-
-ruleNumeral4 :: Rule
-ruleNumeral4 = Rule
+ruleDecsAnd :: Rule
+ruleDecsAnd = Rule
   { name = "number (21..29 31..39 41..49 51..59 61..69 71..79 81..89 91..99)"
   , pattern =
-    [ oneOf [70, 20, 60, 50, 40, 90, 30, 80]
+    [ oneOf [20, 30, 40, 50, 60, 70, 80, 90]
     , regex "e"
     , numberBetween 1 10
     ]
@@ -219,36 +338,13 @@ ruleNumeral4 = Rule
       _ -> Nothing
   }
 
-ruleDozen :: Rule
-ruleDozen = Rule
-  { name = "dozen"
+ruleCentsAnd :: Rule
+ruleCentsAnd = Rule
+  { name = "number (100..199 200..299 300..399 400..499 500..599 600..699 700..799 800..899 900..999)"
   , pattern =
-    [ regex "d(ú|u)zias?"
-    ]
-  , prod = \_ -> integer 12 >>= withGrain 1 >>= withMultipliable
-  }
-
-ruleNumeralDozen :: Rule
-ruleNumeralDozen = Rule
-  { name = "number dozen"
-  , pattern =
-    [ numberBetween 1 11
-    , dimension Numeral
-    ]
-  , prod = \tokens -> case tokens of
-      (Token Numeral (NumeralData {TNumeral.value = v1}):
-       Token Numeral (NumeralData {TNumeral.value = v2, TNumeral.grain = Just g}):
-       _) -> double (v1 * v2) >>= withGrain g
-      _ -> Nothing
-  }
-
-ruleNumerals :: Rule
-ruleNumerals = Rule
-  { name = "numbers (100..999)"
-  , pattern =
-    [ numberBetween 100 1000
+    [ oneOf [100, 200, 300, 400, 500, 600, 700, 800, 900]
     , regex "e"
-    , numberBetween 0 100
+    , numberBetween 1 99
     ]
   , prod = \tokens -> case tokens of
       (Token Numeral (NumeralData {TNumeral.value = v1}):
@@ -258,49 +354,55 @@ ruleNumerals = Rule
       _ -> Nothing
   }
 
-ruleNumeralDotNumeral :: Rule
-ruleNumeralDotNumeral = Rule
-  { name = "number dot number"
+ruleSumAnd :: Rule
+ruleSumAnd = Rule
+  { name = "intersect 2 numbers (with and)"
   , pattern =
-    [ dimension Numeral
-    , regex "ponto"
-    , numberWith TNumeral.grain isNothing
+    [ numberWith (fromMaybe 0 . TNumeral.grain) (>1)
+    , regex "e"
+    , numberWith TNumeral.multipliable not
     ]
   , prod = \tokens -> case tokens of
-      (Token Numeral nd1:_:Token Numeral nd2:_) ->
-        double $ TNumeral.value nd1 + decimalsToDouble (TNumeral.value nd2)
+      (Token Numeral (NumeralData {TNumeral.value = val1, TNumeral.grain = Just g}):
+       _:
+       Token Numeral (NumeralData {TNumeral.value = val2}):
+       _) | (10 ** fromIntegral g) > val2 -> double $ val1 + val2
       _ -> Nothing
   }
 
-ruleIntegerWithThousandsSeparator :: Rule
-ruleIntegerWithThousandsSeparator = Rule
-  { name = "integer with thousands separator ."
+ruleMultiply :: Rule
+ruleMultiply = Rule
+  { name = "compose by multiplication"
   , pattern =
-    [ regex "(\\d{1,3}(\\.\\d\\d\\d){1,5})"
+    [ dimension Numeral
+    , numberWith TNumeral.multipliable id
     ]
   , prod = \tokens -> case tokens of
-      (Token RegexMatch (GroupMatch (match:_)):
-       _) -> let fmt = Text.replace "." Text.empty match
-        in parseDouble fmt >>= double
+      (token1:token2:_) -> multiply token1 token2
       _ -> Nothing
   }
 
 rules :: [Rule]
 rules =
-  [ ruleDecimalNumeral
-  , ruleDecimalWithThousandsSeparator
+  [ ruleIntegers
+  , ruleToNineteen
+  , ruleTens
+  , ruleCent
+  , rulePowersOfTen
+  , ruleCompositeTens
+  , ruleCompositeCents
+  , ruleSkipHundreds
+  , ruleDotSpelledOut
+  , ruleLeadingDotSpelledOut
+  , ruleDecimals
+  , ruleFractions
+  , ruleCommas
+  , ruleSuffixes
+  , ruleNegative
+  , ruleSum
+  , ruleDecsAnd
+  , ruleCentsAnd
+  , ruleSumAnd
+  , ruleMultiply
   , ruleDozen
-  , ruleIntegerNumeric
-  , ruleIntegerWithThousandsSeparator
-  , ruleNumeral
-  , ruleNumeral2
-  , ruleNumeral3
-  , ruleNumeral4
-  , ruleNumeral5
-  , ruleNumeral6
-  , ruleNumeralDotNumeral
-  , ruleNumeralDozen
-  , ruleNumerals
-  , ruleNumeralsPrefixWithNegativeOrMinus
-  , ruleNumeralsSuffixesKMG
   ]


### PR DESCRIPTION
When I write "dois mil e duzentos" the result should be 2200, but duckling recognize the numbers separated and give the result:

`[{"dim":"number","body":"dois","value":{"value":2,"type":"value"},"start":0,"end":4},{"dim":"number","body":"mil","value":{"value":1000,"type":"value"},"start":5,"end":8},{"dim":"time","body":"mil","value":{"values":[],"value":"1000-01-01T00:00:00.000-07:53","grain":"year","type":"value"},"start":5,"end":8},{"dim":"number","body":"duzentos","value":{"value":200,"type":"value"},"start":11,"end":19}]`

Now with this commit, duckling gives the correct result:

`[{"dim":"number","body":"dois mil e duzentos","value":{"value":2200,"type":"value"},"start":0,"end":19}]`
