### PR TITLE
Add note about -j1 flag for stack build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,10 @@ RUN apt-get update
 RUN apt-get install -qq -y libpcre3 libpcre3-dev build-essential --fix-missing --no-install-recommends
 
 RUN stack setup
-
+# NOTE:`stack build` will use as many cores as are available to build
+# in parallel. However, this can cause OOM issues as the linking step
+# in GHC can be expensive. If the build fails, try specifying the
+# '-j1' flag to force the build to run sequentially.
 RUN stack build
 
 ENTRYPOINT stack exec duckling-example-exe


### PR DESCRIPTION
I had trouble building the Docker image on a mac because `stack build` was trying to use all the cores and subsequently running out of memory. It took me a while to find the right flag, so I added a note to the dockerfile.