### PR TITLE
Ordinals with spaces, en-dashes and more!

### DIFF
--- a/Duckling/Ordinal/EN/Corpus.hs
+++ b/Duckling/Ordinal/EN/Corpus.hs
@@ -44,19 +44,31 @@ allExamples = concat
              ]
   , examples (OrdinalData 25)
              [ "twenty-fifth"
+             , "twenty—fifth"
+             , "twenty fifth"
+             , "twentyfifth"
              , "25th"
              ]
   , examples (OrdinalData 31)
              [ "thirty-first"
+             , "thirty—first"
+             , "thirty first"
+             , "thirtyfirst"
              , "31st"
              ]
   , examples (OrdinalData 42)
              [ "forty-second"
+             , "forty—second"
+             , "forty second"
+             , "fortysecond"
              , "42nd"
              ]
-  , examples (OrdinalData 77)
-            [ "seventy-seventh"
-            , "77th"
+  , examples (OrdinalData 73)
+            [ "seventy-third"
+            , "seventy—third"
+            , "seventy third"
+            , "seventythird"
+            , "73rd"
             ]
   , examples (OrdinalData 90)
             [ "ninetieth"

--- a/Duckling/Ordinal/EN/Rules.hs
+++ b/Duckling/Ordinal/EN/Rules.hs
@@ -83,8 +83,8 @@ ruleOrdinals = Rule
 
 ruleCompositeOrdinals :: Rule
 ruleCompositeOrdinals = Rule
-  { name = "ordinals (composite, e.g. eighty-seven forty—seventh twenty ninth thirtythird)"
-  , pattern = [regex "(twenty|thirty|forty|fifty|sixty|seventy|eighty|ninety)[\\s,\\-,\\—]?(first|second|third|fourth|fifth|sixth|seventh|eighth|ninth)"]
+  { name = "ordinals (composite, e.g. eighty-seven, forty—seventh, twenty ninth, thirtythird)"
+  , pattern = [regex "(twenty|thirty|forty|fifty|sixty|seventy|eighty|ninety)[\\s\\-\\—]?(first|second|third|fourth|fifth|sixth|seventh|eighth|ninth)"]
   , prod = \tokens -> case tokens of
       (Token RegexMatch (GroupMatch (tens:units:_)):_) -> do
         tt <- HashMap.lookup (Text.toLower tens) cardinalsMap

--- a/Duckling/Ordinal/EN/Rules.hs
+++ b/Duckling/Ordinal/EN/Rules.hs
@@ -83,7 +83,7 @@ ruleOrdinals = Rule
 
 ruleCompositeOrdinals :: Rule
 ruleCompositeOrdinals = Rule
-  { name = "ordinals (composite, e.g., eighty-seven, forty—seventh, twenty ninth, thirtythird)"
+  { name = "ordinals (composite, e.g. eighty-seven forty—seventh twenty ninth thirtythird)"
   , pattern = [regex "(twenty|thirty|forty|fifty|sixty|seventy|eighty|ninety)[\\s,\\-,\\—]?(first|second|third|fourth|fifth|sixth|seventh|eighth|ninth)"]
   , prod = \tokens -> case tokens of
       (Token RegexMatch (GroupMatch (tens:units:_)):_) -> do

--- a/Duckling/Ordinal/EN/Rules.hs
+++ b/Duckling/Ordinal/EN/Rules.hs
@@ -83,8 +83,8 @@ ruleOrdinals = Rule
 
 ruleCompositeOrdinals :: Rule
 ruleCompositeOrdinals = Rule
-  { name = "ordinals (composite, e.g., eighty-seven)"
-  , pattern = [regex "(twenty|thirty|forty|fifty|sixty|seventy|eighty|ninety)\\-(first|second|third|fourth|fifth|sixth|seventh|eighth|ninth)"]
+  { name = "ordinals (composite, e.g., eighty-seven, forty—seventh, twenty ninth, thirtythird)"
+  , pattern = [regex "(twenty|thirty|forty|fifty|sixty|seventy|eighty|ninety)[\\s,\\-,\\—]?(first|second|third|fourth|fifth|sixth|seventh|eighth|ninth)"]
   , prod = \tokens -> case tokens of
       (Token RegexMatch (GroupMatch (tens:units:_)):_) -> do
         tt <- HashMap.lookup (Text.toLower tens) cardinalsMap


### PR DESCRIPTION
Adding more support for "natural" language compound ordinals:
"twenty nine", "twentynine", and "twenty–nine".

These tend to come up in text that has been transcribed from audio, informal user input, and more formal printed material respectively.