### PR TITLE
Fix PR 151 : bug on parsing amount-of-money in French

### DIFF
--- a/Duckling/AmountOfMoney/FR/Rules.hs
+++ b/Duckling/AmountOfMoney/FR/Rules.hs
@@ -127,7 +127,7 @@ rules :: [Rule]
 rules =
   [ ruleCent
   , ruleIntersect
-  , ruleIntersectAndNumeral
+ -- , ruleIntersectAndNumeral
   , ruleIntersectAndXCents
   , ruleIntersectXCents
   , rulePounds


### PR DESCRIPTION
I propose a solution for fixing the next problem
Expected : 12 EUR
15 EUR
Extracted : 12.15 EUR
15 EUR
This is wrong :
curl -XPOST http://0.0.0.0:8000/parse --data 'locale=fr_FR&text=Les frais de mission entre 12 euros et 15 euros'
[{"dim":"amount-of-money","body":"12 euros et 15","value":{"value":12.15,"type":"value","unit":"EUR"},"start":27,"end":41},{"dim":"amount-of-money","body":"15 euros","value":{"value":15,"type":"value","unit":"EUR"},"start":39,"end":47}]