### PR TITLE
[EN]: DDMMYYYY/MMDDYYYY parsing to phone fix

### DIFF
--- a/Duckling/Ranking/Classifiers/EN_XX.hs
+++ b/Duckling/Ranking/Classifiers/EN_XX.hs
@@ -60,11 +60,12 @@ classifiers
                                likelihoods = HashMap.fromList [], n = 0}}),
        ("integer (numeric)",
         Classifier{okData =
-                     ClassData{prior = -0.7765287894989963, unseen = -5.225746673713201,
+                     ClassData{prior = -0.791417401992747, unseen = -5.225746673713201,
                                likelihoods = HashMap.fromList [("", 0.0)], n = 184},
                    koData =
-                     ClassData{prior = -0.616186139423817, unseen = -5.384495062789089,
-                               likelihoods = HashMap.fromList [("", 0.0)], n = 216}}),
+                     ClassData{prior = -0.6036757777294532,
+                               unseen = -5.4116460518550396,
+                               likelihoods = HashMap.fromList [("", 0.0)], n = 222}}),
        ("<duration> hence|ago",
         Classifier{okData =
                      ClassData{prior = 0.0, unseen = -3.784189633918261,
@@ -1443,13 +1444,14 @@ classifiers
                                n = 47}}),
        ("year",
         Classifier{okData =
-                     ClassData{prior = -0.23483959107740107, unseen = -3.58351893845611,
+                     ClassData{prior = -0.2803019651541584, unseen = -3.58351893845611,
                                likelihoods = HashMap.fromList [("integer (numeric)", 0.0)],
                                n = 34},
                    koData =
-                     ClassData{prior = -1.563975538357343, unseen = -2.3978952727983707,
+                     ClassData{prior = -1.4087672169719492,
+                               unseen = -2.5649493574615367,
                                likelihoods = HashMap.fromList [("integer (numeric)", 0.0)],
-                               n = 9}}),
+                               n = 11}}),
        ("last <day-of-week> of <time>",
         Classifier{okData =
                      ClassData{prior = 0.0, unseen = -2.3978952727983707,
@@ -1843,6 +1845,13 @@ classifiers
                    koData =
                      ClassData{prior = -infinity, unseen = -0.6931471805599453,
                                likelihoods = HashMap.fromList [], n = 0}}),
+       ("dd mm yyyy",
+        Classifier{okData =
+                     ClassData{prior = 0.0, unseen = -1.0986122886681098,
+                               likelihoods = HashMap.fromList [("", 0.0)], n = 1},
+                   koData =
+                     ClassData{prior = -infinity, unseen = -0.6931471805599453,
+                               likelihoods = HashMap.fromList [], n = 0}}),
        ("Christmas",
         Classifier{okData =
                      ClassData{prior = 0.0, unseen = -2.0794415416798357,
@@ -1922,6 +1931,13 @@ classifiers
                    koData =
                      ClassData{prior = 0.0, unseen = -1.6094379124341003,
                                likelihoods = HashMap.fromList [("", 0.0)], n = 3}}),
+       ("mm dd yyyy",
+        Classifier{okData =
+                     ClassData{prior = 0.0, unseen = -1.0986122886681098,
+                               likelihoods = HashMap.fromList [("", 0.0)], n = 1},
+                   koData =
+                     ClassData{prior = -infinity, unseen = -0.6931471805599453,
+                               likelihoods = HashMap.fromList [], n = 0}}),
        ("next <time>",
         Classifier{okData =
                      ClassData{prior = 0.0, unseen = -3.5263605246161616,

--- a/Duckling/Time/EN/Corpus.hs
+++ b/Duckling/Time/EN/Corpus.hs
@@ -41,6 +41,8 @@ defaultCorpus = (testContext, allExamples ++ custom)
                  , "10/31/74"
                  , "10-31-74"
                  , "10.31.1974"
+                 , "10 31 1974"
+                 , "31 10 1974"
                  ]
       , examples (datetime (2013, 4, 25, 16, 0, 0) Minute)
                  [ "4/25 at 4:00pm"

--- a/Duckling/Time/EN/Rules.hs
+++ b/Duckling/Time/EN/Rules.hs
@@ -750,6 +750,36 @@ ruleYYYYMMDD = Rule
       _ -> Nothing
   }
 
+ruleMMDDYYYY :: Rule
+ruleMMDDYYYY = Rule
+  { name = "mm dd yyyy"
+  , pattern =
+    [ regex "(0?[1-9]|1[0-2]) (3[01]|[12]\\d|0?[1-9]) (\\d{2,4})"
+    ]
+  , prod = \tokens -> case tokens of
+      (Token RegexMatch (GroupMatch (mm:dd:yy:_)):_) -> do
+        y <- parseInt yy
+        m <- parseInt mm
+        d <- parseInt dd
+        tt $ yearMonthDay y m d
+      _ -> Nothing
+  }
+
+ruleDDMMYYYY :: Rule
+ruleDDMMYYYY = Rule
+  { name = "dd mm yyyy"
+  , pattern =
+    [ regex "(3[01]|[12]\\d|0?[1-9]) (0?[1-9]|1[0-2]) (\\d{2,4})"
+    ]
+  , prod = \tokens -> case tokens of
+      (Token RegexMatch (GroupMatch (dd:mm:yy:_)):_) -> do
+        y <- parseInt yy
+        m <- parseInt mm
+        d <- parseInt dd
+        tt $ yearMonthDay y m d
+      _ -> Nothing
+  }
+
 ruleNoonMidnightEOD :: Rule
 ruleNoonMidnightEOD = Rule
   { name = "noon|midnight|EOD|end of day"
@@ -1607,6 +1637,8 @@ rules =
   , ruleQuarterAfterHOD
   , ruleHalfHOD
   , ruleYYYYMMDD
+  , ruleMMDDYYYY
+  , ruleDDMMYYYY
   , ruleMMYYYY
   , ruleNoonMidnightEOD
   , rulePartOfDays


### PR DESCRIPTION
"DD MM YYYY", "MM DD YYYY" parsed only as a phone number, but it is also a popular datetime format.
I have added new time patterns and tests for this cases.