### PR TITLE
Remove the use of 'man' for Danish

### DIFF
--- a/Duckling/Time/DA/Corpus.hs
+++ b/Duckling/Time/DA/Corpus.hs
@@ -42,12 +42,11 @@ allExamples = concat
              ]
   , examples (datetime (2013, 2, 18, 0, 0, 0) Day)
              [ "mandag"
-             , "man."
              , "på mandag"
              ]
   , examples (datetime (2013, 2, 18, 0, 0, 0) Day)
              [ "Mandag den 18. februar"
-             , "Man, 18 februar"
+             , "Mandag, 18 februar"
              ]
   , examples (datetime (2013, 2, 19, 0, 0, 0) Day)
              [ "tirsdag"
@@ -144,7 +143,6 @@ allExamples = concat
              ]
   , examples (datetime (2013, 2, 18, 0, 0, 0) Day)
              [ "Mandag, Feb 18"
-             , "Man, februar 18"
              ]
   , examples (datetime (2013, 2, 11, 0, 0, 0) Week)
              [ "denne uge"

--- a/Duckling/Time/DA/Rules.hs
+++ b/Duckling/Time/DA/Rules.hs
@@ -30,7 +30,7 @@ import qualified Duckling.TimeGrain.Types as TG
 
 ruleDaysOfWeek :: [Rule]
 ruleDaysOfWeek = mkRuleDaysOfWeek
-  [ ( "Monday"   , "mandag|man\\.?"           )
+  [ ( "Monday"   , "mandag"         ) -- 'man' is a common Danish word, leading to false positives
   , ( "Tuesday"  , "tirsdag|tirs?\\.?"        )
   , ( "Wednesday", "onsdag|ons\\.?"           )
   , ( "Thursday" , "torsdag|tors?\\.?"        )


### PR DESCRIPTION
This has been bothering me for a while.

In Danish, 'man' means 'you'. E.g. "Kan man det?" translates to "Can you do that?".

As you can imagine, 'man' is used quite frequently. It used to cause a lot of false positives on facebook messenger, but it looks like FM is no longer using Duckling? Either way, unless you add a statistical layer on top of duckling, parsing 'man' as 'Monday' is the exception, not the rule.

This is my first PR, so bear with me if I've overstepped some contribution rules.