### PR TITLE
Flip month-match expressions in VI ng(à)y regex

### DIFF
--- a/Duckling/Time/VI/Corpus.hs
+++ b/Duckling/Time/VI/Corpus.hs
@@ -341,6 +341,9 @@ allExamples = concat
   , examples (datetime (2017, 4, 23, 16, 0, 0) Minute)
              [ "lúc 4:00 chiều ngày 23/4"
              ]
+  , examples (datetime (2017, 10, 12, 0, 0, 0) Day)
+             [ "ngày 12/10"
+             ]
   , examples (datetime (2017, 4, 23, 16, 0, 0) Hour)
              [ "lúc 4 giờ chiều ngày 23 tháng 4"
              ]

--- a/Duckling/Time/VI/Rules.hs
+++ b/Duckling/Time/VI/Rules.hs
@@ -172,7 +172,7 @@ ruleNgyDdmmyyyy = Rule
   { name = "ngày dd/mm/yyyy"
   , pattern =
     [ regex "ng(à)y"
-    , regex "(3[01]|[12]\\d|0?[1-9])[-/](0?[1-9]|1[0-2])[/-](\\d{2,4})"
+    , regex "(3[01]|[12]\\d|0?[1-9])[-/](1[0-2]|0?[1-9])[/-](\\d{2,4})"
     ]
   , prod = \tokens -> case tokens of
       (_:Token RegexMatch (GroupMatch (m1:m2:m3:_)):_) -> do
@@ -864,7 +864,7 @@ ruleNgyDdmm = Rule
   { name = "ngày dd/mm"
   , pattern =
     [ regex "ng(à)y"
-    , regex "(3[01]|[12]\\d|0?[1-9])/(0?[1-9]|1[0-2])"
+    , regex "(3[01]|[12]\\d|0?[1-9])/(1[0-2]|0?[1-9])"
     ]
   , prod = \tokens -> case tokens of
       (_:Token RegexMatch (GroupMatch (dd:mm:_)):_) -> do


### PR DESCRIPTION
Fix issues where date time matching on double-digit months fails for VI.

### Description
Reverse the order of month digit matching in two VI rules. Reversing will attempt to capture a two digit month beginning with 1, then fall back to single digit months optionally preceeded with a 0.

### Motivation and Context
The current regex greedily captures months starting with 1, but only of a single digit. (10, 11, and 12) are left out of this calculation, and thus regexes for capturing ng(à)y fail. This leads us into bad capturing on unexpected rules. When matched properly, the idea rules for matching date times are used.

Resolves #225.

### How has this been tested
I've added to the VI Time Corpus the case in question in #225 and verified its failure at `master` and success on this branch.