### PR TITLE
Norwegian numeral improvements

### DIFF
--- a/Duckling/Numeral/NB/Corpus.hs
+++ b/Duckling/Numeral/NB/Corpus.hs
@@ -90,12 +90,14 @@ allExamples = concat
              , "100000"
              , "100K"
              , "100k"
+             , "100 000"
              ]
   , examples (NumeralValue 3000000)
              [ "3M"
              , "3000K"
              , "3000000"
              , "3.000.000"
+             , "3 000 000"
              ]
   , examples (NumeralValue 1200000)
              [ "1.200.000"
@@ -103,6 +105,7 @@ allExamples = concat
              , "1,2M"
              , "1200K"
              , ",0012G"
+             , "1 200 000"
              ]
   , examples (NumeralValue (-1200000))
              [ "- 1.200.000"
@@ -112,10 +115,12 @@ allExamples = concat
              , "-1,2M"
              , "-1200K"
              , "-,0012G"
+             , "-1 200 000"
              ]
   , examples (NumeralValue 5000)
              [ "5 tusen"
              , "fem tusen"
+             , "5 000"
              ]
   , examples (NumeralValue 100)
              [ "hundre"
@@ -123,4 +128,237 @@ allExamples = concat
   , examples (NumeralValue 5020)
              [ "fem tusen og tjue"
              ]
+  , examples (NumeralValue 1e9)
+             [ "en milliard"
+             ]
+  , examples (NumeralValue 1e12)
+             [ "en billion"
+             ]
+  , examples (NumeralValue 1e15)
+             [ "en billiard"
+             ]
+  , examples (NumeralValue 1e18)
+             [ "en trillion"
+             ]
+  , examples (NumeralValue 1e21)
+             [ "en trilliard"
+             ]
+  , examples (NumeralValue 1e24)
+             [ "en kvadrillion"
+             ]
+  , examples (NumeralValue 1e27)
+             [ "en kvadrilliard"
+             ]
+  , examples (NumeralValue 6e10)
+             [ "seksti milliarder"
+             , "60 milliarder"
+             ]
+  , examples (NumeralValue 3e12)
+             [ "tre billioner"
+             , "3 billioner"
+             ]
+  , examples (NumeralValue 4e17)
+             [ "fire hundre billiarder"
+             , "400 billiarder"
+             ]
+  , examples (NumeralValue 2e18)
+             [ "to trillioner"
+             , "2 trillioner"
+             ]
+  , examples (NumeralValue 1.8e22)
+             [ "atten trilliarder"
+             , "18 trilliarder"
+             ]
+  , examples (NumeralValue 1.8e22)
+             [ "atten trilliarder"
+             , "18 trilliarder"
+             ]
+  , examples (NumeralValue 4.11e26)
+             [ "fire hundre og elleve kvadrillioner"
+             , "411 kvadrillioner"
+             ]
+  , examples (NumeralValue 9e27)
+             [ "ni kvadrilliarder"
+             , "9 kvadrilliarder"
+             ]
+  , examples (NumeralValue 21)
+             [ "tjueen"
+             , "tjueén" ]
+  , examples (NumeralValue 22)
+             [ "tjueto" ]
+  , examples (NumeralValue 23)
+             [ "tjuetre" ]
+  , examples (NumeralValue 24)
+             [ "tjuefire" ]
+  , examples (NumeralValue 25)
+             [ "tjuefem" ]
+  , examples (NumeralValue 26)
+             [ "tjueseks" ]
+  , examples (NumeralValue 27)
+             [ "tjuesju"
+             , "tjuesyv"
+             ]
+  , examples (NumeralValue 28)
+             [ "tjueåtte" ]
+  , examples (NumeralValue 29)
+             [ "tjueni" ]
+  , examples (NumeralValue 31)
+             [ "trettien"
+             , "trettién" ]
+  , examples (NumeralValue 32)
+             [ "trettito" ]
+  , examples (NumeralValue 33)
+             [ "trettitre" ]
+  , examples (NumeralValue 34)
+             [ "trettifire" ]
+  , examples (NumeralValue 35)
+             [ "trettifem" ]
+  , examples (NumeralValue 36)
+             [ "trettiseks" ]
+  , examples (NumeralValue 37)
+             [ "trettisju"
+             , "trettisyv"
+             ]
+  , examples (NumeralValue 38)
+             [ "trettiåtte" ]
+  , examples (NumeralValue 39)
+             [ "trettini" ]
+  , examples (NumeralValue 41)
+             [ "førtien"
+             , "førtién" ]
+  , examples (NumeralValue 42)
+             [ "førtito" ]
+  , examples (NumeralValue 43)
+             [ "førtitre" ]
+  , examples (NumeralValue 44)
+             [ "førtifire" ]
+  , examples (NumeralValue 45)
+             [ "førtifem" ]
+  , examples (NumeralValue 46)
+             [ "førtiseks" ]
+  , examples (NumeralValue 47)
+             [ "førtisju"
+             , "førtisyv"
+             ]
+  , examples (NumeralValue 48)
+             [ "førtiåtte" ]
+  , examples (NumeralValue 49)
+             [ "førtini" ]
+  , examples (NumeralValue 51)
+             [ "femtien"
+             , "femtién" ]
+  , examples (NumeralValue 52)
+             [ "femtito" ]
+  , examples (NumeralValue 53)
+             [ "femtitre" ]
+  , examples (NumeralValue 54)
+             [ "femtifire" ]
+  , examples (NumeralValue 55)
+             [ "femtifem" ]
+  , examples (NumeralValue 56)
+             [ "femtiseks" ]
+  , examples (NumeralValue 57)
+             [ "femtisju"
+             , "femtisyv"
+             ]
+  , examples (NumeralValue 58)
+             [ "femtiåtte" ]
+  , examples (NumeralValue 59)
+             [ "femtini" ]
+  , examples (NumeralValue 61)
+             [ "sekstien"
+             , "sekstién" ]
+  , examples (NumeralValue 62)
+             [ "sekstito" ]
+  , examples (NumeralValue 63)
+             [ "sekstitre" ]
+  , examples (NumeralValue 64)
+             [ "sekstifire" ]
+  , examples (NumeralValue 65)
+             [ "sekstifem" ]
+  , examples (NumeralValue 66)
+             [ "sekstiseks" ]
+  , examples (NumeralValue 67)
+             [ "sekstisju"
+             , "sekstisyv"
+             ]
+  , examples (NumeralValue 68)
+             [ "sekstiåtte" ]
+  , examples (NumeralValue 69)
+             [ "sekstini" ]
+  , examples (NumeralValue 71)
+             [ "syttien"
+             , "søttien"
+             , "søttién"
+             , "søttién" ]
+  , examples (NumeralValue 72)
+             [ "syttito"
+             , "søttito" ]
+  , examples (NumeralValue 73)
+             [ "syttitre"
+             , "søttitre" ]
+  , examples (NumeralValue 74)
+             [ "syttifire"
+             , "søttifire" ]
+  , examples (NumeralValue 75)
+             [ "syttifem"
+             , "søttifem" ]
+  , examples (NumeralValue 76)
+             [ "syttiseks"
+             , "søttiseks" ]
+  , examples (NumeralValue 77)
+             [ "syttisju"
+             , "syttisju"
+             , "søttisyv"
+             , "søttisyv"
+             ]
+  , examples (NumeralValue 78)
+             [ "søttiåtte"
+             , "søttiåtte" ]
+  , examples (NumeralValue 79)
+             [ "søttini"
+             , "søttini" ]
+  , examples (NumeralValue 81)
+             [ "åttien"
+             , "åttién" ]
+  , examples (NumeralValue 82)
+             [ "åttito" ]
+  , examples (NumeralValue 83)
+             [ "åttitre" ]
+  , examples (NumeralValue 84)
+             [ "åttifire" ]
+  , examples (NumeralValue 85)
+             [ "åttifem" ]
+  , examples (NumeralValue 86)
+             [ "åttiseks" ]
+  , examples (NumeralValue 87)
+             [ "åttisju"
+             , "åttisyv"
+             ]
+  , examples (NumeralValue 88)
+             [ "åttiåtte" ]
+  , examples (NumeralValue 89)
+             [ "åttini" ]
+  , examples (NumeralValue 91)
+             [ "nittien"
+             , "nittién" ]
+  , examples (NumeralValue 92)
+             [ "nittito" ]
+  , examples (NumeralValue 93)
+             [ "nittitre" ]
+  , examples (NumeralValue 94)
+             [ "nittifire" ]
+  , examples (NumeralValue 95)
+             [ "nittifem" ]
+  , examples (NumeralValue 96)
+             [ "nittiseks" ]
+  , examples (NumeralValue 97)
+             [ "nittisju"
+             , "nittisyv"
+             ]
+  , examples (NumeralValue 98)
+             [ "nittiåtte" ]
+  , examples (NumeralValue 99)
+             [ "nittini" ]
+
   ]

--- a/Duckling/Numeral/NB/Rules.hs
+++ b/Duckling/Numeral/NB/Rules.hs
@@ -161,7 +161,7 @@ rulePowersOfTen :: Rule
 rulePowersOfTen = Rule
   { name = "powers of tens"
   , pattern =
-    [ regex "(hundre(de)?|tusen?|million(er)?)"
+    [ regex "(hundre(de)?|tusen?|million(er)?|milliard(?:er)?|billion(?:er)?|billiard(?:er)?|trillion(?:er)?|trilliard(?:er)?|kvadrillion(?:er)?|kvadrilliard(?:er)?)"
     ]
   , prod = \tokens -> case tokens of
       (Token RegexMatch (GroupMatch (match:_)):_) -> case Text.toLower match of
@@ -171,6 +171,20 @@ rulePowersOfTen = Rule
         "tusen"     -> double 1e3 >>= withGrain 3 >>= withMultipliable
         "million"   -> double 1e6 >>= withGrain 6 >>= withMultipliable
         "millioner" -> double 1e6 >>= withGrain 6 >>= withMultipliable
+        "milliard" -> double 1e9 >>= withGrain 9 >>= withMultipliable
+        "milliarder" -> double 1e9 >>= withGrain 9 >>= withMultipliable
+        "billion" -> double 1e12 >>= withGrain 12 >>= withMultipliable
+        "billioner" -> double 1e12 >>= withGrain 12 >>= withMultipliable
+        "billiard" -> double 1e15 >>= withGrain 15 >>= withMultipliable
+        "billiarder" -> double 1e15 >>= withGrain 15 >>= withMultipliable
+        "trillion" -> double 1e18 >>= withGrain 18 >>= withMultipliable
+        "trillioner" -> double 1e18 >>= withGrain 18 >>= withMultipliable
+        "trilliard" -> double 1e21 >>= withGrain 21 >>= withMultipliable
+        "trilliarder" -> double 1e21 >>= withGrain 21 >>= withMultipliable
+        "kvadrillion" -> double 1e24 >>= withGrain 24 >>= withMultipliable
+        "kvadrillioner" -> double 1e24 >>= withGrain 24 >>= withMultipliable
+        "kvadrilliard" -> double 1e27 >>= withGrain 27 >>= withMultipliable
+        "kvadrilliarder" -> double 1e27 >>= withGrain 27 >>= withMultipliable
         _           -> Nothing
       _ -> Nothing
   }
@@ -235,6 +249,132 @@ ruleInteger = Rule
       _ -> Nothing
   }
 
+
+twentyToHundredMap :: HashMap Text Integer
+twentyToHundredMap = HashMap.fromList
+  [ ( "tjueen" , 21 )
+  , ( "tjueén" , 21 )
+  , ( "tjueto" , 22 )
+  , ( "tjuetre" , 23 )
+  , ( "tjuefire" , 24 )
+  , ( "tjuefem" , 25 )
+  , ( "tjueseks" , 26 )
+  , ( "tjuesju" , 27 )
+  , ( "tjuesyv" , 27 )
+  , ( "tjueåtte" , 28 )
+  , ( "tjueni" , 29 )
+  , ( "trettien" , 31 )
+  , ( "trettién" , 31 )
+  , ( "trettito" , 32 )
+  , ( "trettitre" , 33 )
+  , ( "trettifire" , 34 )
+  , ( "trettifem" , 35 )
+  , ( "trettiseks" , 36 )
+  , ( "trettisju" , 37 )
+  , ( "trettisyv" , 37 )
+  , ( "trettiåtte" , 38 )
+  , ( "trettini" , 39 )
+  , ( "førtien" , 41 )
+  , ( "førtién" , 41 )
+  , ( "førtito" , 42 )
+  , ( "førtitre" , 43 )
+  , ( "førtifire" , 44 )
+  , ( "førtifem" , 45 )
+  , ( "førtiseks" , 46 )
+  , ( "førtisju" , 47 )
+  , ( "førtisyv" , 47 )
+  , ( "førtiåtte" , 48 )
+  , ( "førtini" , 49 )
+  , ( "femtien" , 51 )
+  , ( "femtién" , 51 )
+  , ( "femtito" , 52 )
+  , ( "femtitre" , 53 )
+  , ( "femtifire" , 54 )
+  , ( "femtifem" , 55 )
+  , ( "femtiseks" , 56 )
+  , ( "femtisju" , 57 )
+  , ( "femtisyv" , 57 )
+  , ( "femtiåtte" , 58 )
+  , ( "femtini" , 59 )
+  , ( "sekstien" , 61 )
+  , ( "sekstién" , 61 )
+  , ( "sekstito" , 62 )
+  , ( "sekstitre" , 63 )
+  , ( "sekstifire" , 64 )
+  , ( "sekstifem" , 65 )
+  , ( "sekstiseks" , 66 )
+  , ( "sekstisju" , 67 )
+  , ( "sekstisyv" , 67 )
+  , ( "sekstiåtte" , 68 )
+  , ( "sekstini" , 69 )
+  , ( "syttien" , 71 )
+  , ( "syttién" , 71 )
+  , ( "syttito" , 72 )
+  , ( "syttitre" , 73 )
+  , ( "syttifire" , 74 )
+  , ( "syttifem" , 75 )
+  , ( "syttiseks" , 76 )
+  , ( "syttisju" , 77 )
+  , ( "syttisyv" , 77 )
+  , ( "syttiåtte" , 78 )
+  , ( "syttini" , 79 )
+  , ( "søttien" , 71 )
+  , ( "søttién" , 71 )
+  , ( "søttito" , 72 )
+  , ( "søttitre" , 73 )
+  , ( "søttifire" , 74 )
+  , ( "søttifem" , 75 )
+  , ( "søttiseks" , 76 )
+  , ( "søttisju" , 77 )
+  , ( "søttisyv" , 77 )
+  , ( "søttiåtte" , 78 )
+  , ( "søttini" , 79 )
+  , ( "åttien" , 81 )
+  , ( "åttién" , 81 )
+  , ( "åttito" , 82 )
+  , ( "åttitre" , 83 )
+  , ( "åttifire" , 84 )
+  , ( "åttifem" , 85 )
+  , ( "åttiseks" , 86 )
+  , ( "åttisju" , 87 )
+  , ( "åttisyv" , 87 )
+  , ( "åttiåtte" , 88 )
+  , ( "åttini" , 89 )
+  , ( "nittien" , 91 )
+  , ( "nittién" , 91 )
+  , ( "nittito" , 92 )
+  , ( "nittitre" , 93 )
+  , ( "nittifire" , 94 )
+  , ( "nittifem" , 95 )
+  , ( "nittiseks" , 96 )
+  , ( "nittisju" , 97 )
+  , ( "nittisyv" , 97 )
+  , ( "nittiåtte" , 98 )
+  , ( "nittini" , 99 )
+  ]
+
+ruleInteger4 :: Rule
+ruleInteger4 = Rule
+  { name = "integer (21..99)"
+  , pattern =
+    [ regex "(tjueen|tjueén|tjueto|tjuetre|tjuefire|tjuefem|tjueseks|tjuesju|tjuesyv|tjueåtte|tjueni\
+            \|trettien|trettién|trettito|trettitre|trettifire|trettifem|trettiseks|trettisju|trettisyv|trettiåtte|trettini\
+            \|førtien|førtién|førtito|førtitre|førtifire|førtifem|førtiseks|førtisju|førtisyv|førtiåtte|førtini\
+            \|femtien|femtién|femtito|femtitre|femtifire|femtifem|femtiseks|femtisju|femtisyv|femtiåtte|femtini\
+            \|sekstien|sekstién|sekstito|sekstitre|sekstifire|sekstifem|sekstiseks|sekstisju|sekstisyv|sekstiåtte|sekstini\
+            \|syttien|syttién|syttito|syttitre|syttifire|syttifem|syttiseks|syttisju|syttisyv|syttiåtte|syttini\
+            \|søttien|søttién|søttito|søttitre|søttifire|søttifem|søttiseks|søttisju|søttisyv|søttiåtte|søttini\
+            \|åttien|åttién|åttito|åttitre|åttifire|åttifem|åttiseks|åttisju|åttisyv|åttiåtte|åttini\
+            \|nittien|nittién|nittito|nittitre|nittifire|nittifem|nittiseks|nittisju|nittisyv|nittiåtte|nittini\
+            \)"
+    ]
+  , prod = \tokens -> case tokens of
+      (Token RegexMatch (GroupMatch (match:_)):_) ->
+        HashMap.lookup (Text.toLower match) twentyToHundredMap >>= integer
+      _ -> Nothing
+  }
+
+
 tensMap :: HashMap Text Integer
 tensMap = HashMap.fromList
   [ ( "tyve" , 20 )
@@ -280,11 +420,11 @@ ruleIntegerWithThousandsSeparator :: Rule
 ruleIntegerWithThousandsSeparator = Rule
   { name = "integer with thousands separator ."
   , pattern =
-    [ regex "(\\d{1,3}(\\.\\d\\d\\d){1,5})"
+    [ regex "(\\d{1,3}((?:\\.| )\\d\\d\\d){1,5})"
     ]
   , prod = \tokens -> case tokens of
       (Token RegexMatch (GroupMatch (match:_)):_) ->
-        parseDouble (Text.replace "." Text.empty match) >>= double
+        parseDouble (Text.replace " " Text.empty . Text.replace "." Text.empty $ match) >>= double
       _ -> Nothing
   }
 
@@ -298,6 +438,7 @@ rules =
   , ruleInteger
   , ruleInteger2
   , ruleInteger3
+  , ruleInteger4
   , ruleIntegerWithThousandsSeparator
   , ruleIntersect
   , ruleIntersectWithAnd


### PR DESCRIPTION
Some small improvements to Norwegian numerals:

- Parse powers of ten with spaces as well as dots: `10 000 == 10.000`
- Some more textual powers of ten: `milliard`, `billion`, ...
- Textual numbers from 21 to 99: `tjueen`, `tjueto`, ...
   (they were already parsed with spaces, as in `tjue en`, but not without)