### PR TITLE
small bugfix in german numeral dimension

### DIFF
--- a/Duckling/Numeral/DE/Corpus.hs
+++ b/Duckling/Numeral/DE/Corpus.hs
@@ -59,6 +59,10 @@ allExamples = concat
              [ "14"
              , "vierzehn"
              ]
+  , examples (NumeralValue 15)
+             [ "15"
+             , "fünfzehn"
+             ]
   , examples (NumeralValue 16)
              [ "16"
              , "sechzehn"

--- a/Duckling/Numeral/DE/Rules.hs
+++ b/Duckling/Numeral/DE/Rules.hs
@@ -255,7 +255,7 @@ ruleZeroToNineteen :: Rule
 ruleZeroToNineteen = Rule
   { name = "integer (0..19)"
   , pattern =
-    [ regex "(keine[rn]|keine?s?|null|nichts|eins?(er)?|zwei|dreizehn|drei|vierzehn|vier|fünf|sechzehn|sechs|siebzehn|sieben|achtzehn|acht|neunzehn|neun|elf|zwölf|füfzehn)"
+    [ regex "(keine[rn]|keine?s?|null|nichts|eins?(er)?|zwei|dreizehn|drei|vierzehn|vier|fünfzehn|fünf|sechzehn|sechs|siebzehn|sieben|achtzehn|acht|neunzehn|neun|elf|zwölf)"
     ]
   , prod = \tokens -> case tokens of
       (Token RegexMatch (GroupMatch (match:_)):_) ->


### PR DESCRIPTION
There is a small bug in the German numeral dimension. The number "fünfzehn"(15) cannot be recognized correctly due to a typo. This pull request should fix it:)