### PR TITLE
Recognize time from abbreviation 'kl'

### DIFF
--- a/Duckling/Time/DA/Corpus.hs
+++ b/Duckling/Time/DA/Corpus.hs
@@ -262,6 +262,7 @@ allExamples = concat
   , examples (datetime (2013, 2, 13, 3, 0, 0) Hour)
              [ "klokken 3"
              , "kl. 3"
+             , "kl 3"
              ]
   , examples (datetime (2013, 2, 13, 3, 18, 0) Minute)
              [ "3:18"
@@ -269,16 +270,19 @@ allExamples = concat
   , examples (datetime (2013, 2, 12, 15, 0, 0) Hour)
              [ "klokken 15"
              , "kl. 15"
+             , "kl 15"
              , "15h"
              ]
   , examples (datetime (2013, 2, 12, 15, 0, 0) Hour)
              [ "ca. kl. 15"
              , "cirka kl. 15"
+             , "cirka kl 15"
              , "omkring klokken 15"
              ]
   , examples (datetime (2013, 2, 13, 17, 0, 0) Hour)
              [ "imorgen klokken 17 sharp"
              , "imorgen kl. 17 præcis"
+             , "imorgen kl 17 præcis"
              ]
   , examples (datetime (2013, 2, 12, 15, 15, 0) Minute)
              [ "kvarter over 15"
@@ -289,6 +293,7 @@ allExamples = concat
              [ "kl. 20 over 15"
              , "klokken 20 over 15"
              , "kl. 15:20"
+             , "kl 15:20"
              , "15:20"
              ]
   , examples (datetime (2013, 2, 12, 15, 30, 0) Minute)
@@ -314,6 +319,7 @@ allExamples = concat
              ]
   , examples (datetime (2014, 9, 20, 19, 30, 0) Minute)
              [ "kl. 19:30, Lør, 20 sep"
+             , "kl 19:30, Lør, 20 sep"
              ]
   , examples (datetime (2013, 2, 12, 4, 30, 1) Second)
              [ "om 1 sekund"
@@ -552,16 +558,19 @@ allExamples = concat
   , examples (datetimeOpenInterval Before (2013, 2, 12, 14, 0, 0) Hour)
              [ "inden kl. 14"
              , "indtil kl. 14"
+             , "indtil kl 14"
              , "inden klokken 14"
              ]
   , examples (datetime (2013, 2, 12, 13, 0, 0) Minute)
              [ "@ 16 CET"
              , "kl. 16 CET"
+             , "kl 16 CET"
              , "klokken 16 CET"
              ]
   , examples (datetime (2013, 2, 14, 6, 0, 0) Minute)
              [ "torsdag kl. 8:00 GMT"
              , "torsdag kl. 8:00 gmt"
+             , "torsdag kl 8:00 gmt"
              , "torsdag klokken 8:00 GMT"
              , "torsdag klokken 8:00 gmt"
              , "torsdag 08:00 GMT"
@@ -569,23 +578,30 @@ allExamples = concat
              ]
   , examples (datetime (2013, 2, 12, 14, 0, 0) Hour)
              [ "idag kl. 14"
+             , "i dag kl. 14"
+             , "i dag kl. 14"
              , "idag klokken 14"
              , "kl. 14"
+             , "kl 14"
              , "klokken 14"
              ]
   , examples (datetime (2013, 4, 25, 16, 0, 0) Minute)
              [ "25/4 kl. 16:00"
+             , "25/4 kl 16:00"
              , "25/4 klokken 16:00"
              , "25-04 klokken 16:00"
              , "25-4 kl. 16:00"
+             , "25-4 kl 16:00"
              ]
   , examples (datetime (2013, 2, 13, 15, 0, 0) Minute)
              [ "15:00 i morgen"
              , "kl. 15:00 i morgen"
+             , "kl 15:00 i morgen"
              , "klokken 15:00 i morgen"
              ]
   , examples (datetimeOpenInterval After (2013, 2, 12, 14, 0, 0) Hour)
              [ "efter kl. 14"
+             , "efter kl 14"
              , "efter klokken 14"
              ]
   , examples (datetimeOpenInterval After (2013, 2, 17, 4, 0, 0) Hour)
@@ -598,16 +614,20 @@ allExamples = concat
              ]
   , examples (datetimeOpenInterval After (2013, 2, 13, 14, 0, 0) Hour)
              [ "efter i morgen kl. 14"
+             , "efter i morgen kl 14"
              , "efter i morgen klokken 14"
              , "i morgen efter kl. 14"
+             , "i morgen efter kl 14"
              , "i morgen efter klokken 14"
              ]
   , examples (datetimeOpenInterval Before (2013, 2, 12, 11, 0, 0) Hour)
              [ "før kl. 11"
+             , "før kl 11"
              , "før klokken 11"
              ]
   , examples (datetimeOpenInterval Before (2013, 2, 13, 11, 0, 0) Hour)
              [ "i morgen før kl. 11"
+             , "i morgen før kl 11"
              , "i morgen før klokken 11"
              ]
   , examples (datetimeInterval ((2013, 2, 12, 12, 0, 0), (2013, 2, 12, 19, 0, 0)) Hour)
@@ -615,6 +635,7 @@ allExamples = concat
              ]
   , examples (datetime (2013, 2, 12, 13, 30, 0) Minute)
              [ "kl. 13:30"
+             , "kl 13:30"
              , "klokken 13:30"
              ]
   , examples (datetime (2013, 2, 12, 4, 45, 0) Second)

--- a/Duckling/Time/DA/Rules.hs
+++ b/Duckling/Time/DA/Rules.hs
@@ -1007,7 +1007,7 @@ ruleAtTimeofday :: Rule
 ruleAtTimeofday = Rule
   { name = "at <time-of-day>"
   , pattern =
-    [ regex "klokken|kl|kl\\.|@"
+    [ regex "klokken|kl |kl\\. |@"
     , Predicate isATimeOfDay
     ]
   , prod = \tokens -> case tokens of

--- a/Duckling/Time/DA/Rules.hs
+++ b/Duckling/Time/DA/Rules.hs
@@ -799,7 +799,7 @@ ruleExactlyTimeofday :: Rule
 ruleExactlyTimeofday = Rule
   { name = "exactly <time-of-day>"
   , pattern =
-    [ regex "pr(æ)cis( kl\\.| klokken)?"
+    [ regex "pr(æ)cis( kl\\.| klokken | kl)?"
     , Predicate isATimeOfDay
     ]
   , prod = \tokens -> case tokens of
@@ -983,7 +983,7 @@ ruleAboutTimeofday :: Rule
 ruleAboutTimeofday = Rule
   { name = "about <time-of-day>"
   , pattern =
-    [ regex "(omkring|cirka|ca\\.)( kl\\.| klokken)?"
+    [ regex "(omkring|cirka|ca\\.)( kl\\.| klokken| kl)?"
     , Predicate isATimeOfDay
     ]
   , prod = \tokens -> case tokens of
@@ -1007,7 +1007,7 @@ ruleAtTimeofday :: Rule
 ruleAtTimeofday = Rule
   { name = "at <time-of-day>"
   , pattern =
-    [ regex "klokken|kl\\.|@"
+    [ regex "klokken|kl|kl\\.|@"
     , Predicate isATimeOfDay
     ]
   , prod = \tokens -> case tokens of


### PR DESCRIPTION
The common phrase "i dag kl 15" (today at 15:00) will now be recognized with the correct time.
So far duckling has expected the 'kl' to be written as 'kl.'.

Before this pull
`$ curl -XPOST http://0.0.0.0:8000/parse --data 'locale=da_DK&text=i dag kl 15'`
Time is 00:00:00:
```
[{"body":"i dag","start":0,"value":{"values":[{"value":"2018-10-18T00:00:00.000-07:00","grain":"day","type":"value"}],
	**"value":"2018-10-18T00:00:00.000-07:00",**
"grain":"day","type":"value"},"end":5,"dim":"time","latent":false},{"body":"15","start":9,"value":{"value":15,"type":"value"},"end":11,"dim":"number","latent":false}]
```


`$ curl -XPOST http://0.0.0.0:8000/parse --data 'locale=da_DK&text=i dag kl. 15'`
Time is 15:00:00:
```
[{"body":"i dag kl. 15","start":0,"value":{"values":[{"value":"2018-10-18T15:00:00.000-07:00","grain":"hour","type":"value"}],
	"value":"2018-10-18T15:00:00.000-07:00",
"grain":"hour","type":"value"},"end":12,"dim":"time","latent":false}]
```

After this pull:
`$ curl -XPOST http://0.0.0.0:8000/parse --data 'locale=da_DK&text=i dag kl 15'`
Time is 15:00:00
```
[{"body":"i dag kl 15","start":0,"value":{"values":[{"value":"2018-10-18T15:00:00.000-07:00","grain":"hour","type":"value"}],
	"value":"2018-10-18T15:00:00.000-07:00",
"grain":"hour","type":"value"},"end":11,"dim":"time","latent":false}]
```
