### PR TITLE
fix issue #249 (wrong parsing of yyyy-mm-dd dates in DE)

### DIFF
--- a/Duckling/Time/DE/Corpus.hs
+++ b/Duckling/Time/DE/Corpus.hs
@@ -15,6 +15,7 @@ module Duckling.Time.DE.Corpus
 
 import Data.String
 import Prelude
+import Data.Time
 
 import Duckling.Locale
 import Duckling.Resolve
@@ -36,7 +37,7 @@ negativeCorpus = (testContext {locale = makeLocale DE Nothing}, testOptions, exa
       ]
 
 allExamples :: [Example]
-allExamples = concat
+allExamples = concat $
   [ examples (datetime (2013, 2, 12, 4, 30, 0) Second)
              [ "jetzt"
              , "genau jetzt"
@@ -631,7 +632,7 @@ allExamples = concat
   , examples (datetime (2013, 12, 10, 0, 0, 0) Day)
              [ "10.12."
              ]
-  , examples (datetimeInterval ((2013, 2, 12, 18, 30, 0), (2013, 2, 12, 19, 1, 0)) Minute)
+  , examples (datetimeInterval ((2013, 2, 12, 18, 30, 0), (2013, 2, 12, 19, 1, 0)) Minute)
              [ "18:30h - 19:00h"
              , "18:30h/19:00h"
              ]
@@ -666,4 +667,8 @@ allExamples = concat
   , examples (datetime (2013, 2, 12, 17, 10, 0) Minute)
              [ "17h10"
              ]
+  ]++
+  [ examples (datetime (yyyy, mm, dd, 0, 0, 0) Day) [fromString $ show day]
+  | day <- [fromGregorian 2016 1 1..fromGregorian 2018 12 31]
+  , let (yyyy,mm,dd) = toGregorian day
   ]

--- a/Duckling/Time/DE/Rules.hs
+++ b/Duckling/Time/DE/Rules.hs
@@ -20,7 +20,7 @@ import qualified Data.Text as Text
 import Duckling.Dimensions.Types
 import Duckling.Numeral.Helpers (parseInt)
 import Duckling.Ordinal.Types (OrdinalData (..))
-import Duckling.Regex.Types
+import Duckling.Regex.Types (GroupMatch(..))
 import Duckling.Time.Helpers
 import Duckling.Time.Types (TimeData (..))
 import Duckling.Types
@@ -1050,7 +1050,7 @@ ruleYyyymmdd :: Rule
 ruleYyyymmdd = Rule
   { name = "yyyy-mm-dd"
   , pattern =
-    [ regex "(\\d{2,4})-(0?[1-9]|10|11|12)-([012]?[1-9]|10|20|30|31)"
+    [ regex "(\\d{2,4})-(0?[1-9]|1[0-2])-(3[01]|[12]\\d|0?[1-9])"
     ]
   , prod = \tokens -> case tokens of
       (Token RegexMatch (GroupMatch (m1:m2:m3:_)):_) -> do


### PR DESCRIPTION

- took regex from EN (which is working)
- added test cases from 2016-01-01 to 2018-12-31

- change non-breaking space to regular space