### PR TITLE
Added Quantity for NL, small fix for Volume for NL

### DIFF
--- a/Duckling/Quantity/NL/Corpus.hs
+++ b/Duckling/Quantity/NL/Corpus.hs
@@ -1,0 +1,68 @@
+-- Copyright (c) 2016-present, Facebook, Inc.
+-- All rights reserved.
+--
+-- This source code is licensed under the BSD-style license found in the
+-- LICENSE file in the root directory of this source tree. An additional grant
+-- of patent rights can be found in the PATENTS file in the same directory.
+
+
+{-# LANGUAGE OverloadedStrings #-}
+
+module Duckling.Quantity.NL.Corpus
+  ( corpus ) where
+
+import Prelude
+import Data.String
+
+import Duckling.Quantity.Types
+import Duckling.Testing.Types
+
+corpus :: Corpus
+corpus = (testContext, testOptions, allExamples)
+
+allExamples :: [Example]
+allExamples = concat
+  [ examples (simple Gram 2 Nothing)
+             [ "2 gram"
+             , "0.002 kg"
+             , "2/1000 kilogram"
+             , "2000 milligram"
+             ]
+  , examples (simple Gram 1000 Nothing)
+             [ "een kilogram"
+             , "een kilo"
+             , "een kilootje"
+             , "een kg"
+             , "1 kilo"
+             , "1 kg"
+             , "1.0 kg"
+             , "1 kilogram"
+             , "1000 gram"
+             , "1000 g"
+             , "1000 gr"
+             , "duizend gram"
+             , "duizend gr"
+             ]
+  , examples (simple Gram 500 (Just "aardbeien"))
+             [ "500 gram aardbeien"
+             , "0.5 kilogram aardbeien"
+             , "halve kilo aardbeien"
+             , "0.5 kilo aardbeien"
+             , "0.5 kg aardbeien"
+             , "500000mg aardbeien"
+             ]
+  , examples (between Gram (100,1000) (Just "aardbeien"))
+              [ "100-1000 gram aardbeien"
+              , "tussen 100 en 1000 gram aardbeien"
+              , "van 100 tot 1000 g aardbeien"
+              , "100 - 1000 g aardbeien"
+              ]
+  , examples (between Gram (2,7) Nothing)
+              [ "rond 2 -7 g"
+              , "~2-7 gram"
+              , "van 2 tot 7 g"
+              , "tussen 2.0 g en ongeveer 7.0 g"
+              , "tussen 0.002 kg en ongeveer 0.007 kg"
+              , "2 - ~7 gram"
+              ]
+  ]

--- a/Duckling/Quantity/NL/Rules.hs
+++ b/Duckling/Quantity/NL/Rules.hs
@@ -1,0 +1,237 @@
+-- Copyright (c) 2016-present, Facebook, Inc.
+-- All rights reserved.
+--
+-- This source code is licensed under the BSD-style license found in the
+-- LICENSE file in the root directory of this source tree. An additional grant
+-- of patent rights can be found in the PATENTS file in the same directory.
+
+
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE LambdaCase #-}
+
+module Duckling.Quantity.NL.Rules
+  ( rules
+  ) where
+
+import Data.HashMap.Strict (HashMap)
+import Data.String
+import Data.Text (Text)
+import Prelude
+import qualified Data.HashMap.Strict as HashMap
+import qualified Data.Text as Text
+
+import Duckling.Dimensions.Types
+import Duckling.Numeral.Helpers
+import Duckling.Quantity.Helpers
+import Duckling.Regex.Types
+import Duckling.Types
+import Duckling.Numeral.Types (NumeralData (..))
+import Duckling.Quantity.Types (QuantityData(..))
+import qualified Duckling.Numeral.Types as TNumeral
+import qualified Duckling.Quantity.Types as TQuantity
+
+quantities :: [(Text, String, TQuantity.Unit)]
+quantities =
+  [ ("<quantity> kopje", "(kopje?)", TQuantity.Cup)
+  , ("<quantity> gram", "(((m(illi)?)|(k(ilo)?))?g(ram)?)", TQuantity.Gram)
+  , ("<quantity> pond", "(pond?)", TQuantity.Gram)
+  , ("<quantity> ons", "(ons?)", TQuantity.Gram)
+  ]
+
+opsMap :: HashMap Text (Double -> Double)
+opsMap = HashMap.fromList
+  [ ( "milligram" , (/ 1000))
+  , ( "mg"        , (/ 1000))
+  , ( "kilogram"  , (* 1000))
+  , ( "kg"        , (* 1000))
+  , ( "pond"      , (* 500))
+  , ( "ons"       , (* 100))
+  ]
+
+getValue :: Text -> Double -> Double
+getValue match = HashMap.lookupDefault id (Text.toLower match) opsMap
+
+ruleNumeralQuantities :: [Rule]
+ruleNumeralQuantities = map go quantities
+  where
+    go :: (Text, String, TQuantity.Unit) -> Rule
+    go (name, regexPattern, u) = Rule
+      { name = name
+      , pattern = [Predicate isPositive, regex regexPattern]
+      , prod = \case
+        (Token Numeral nd:
+         Token RegexMatch (GroupMatch (match:_)):
+         _) -> Just . Token Quantity $ quantity u value
+          where value = getValue match $ TNumeral.value nd
+        _ -> Nothing
+      }
+
+ruleAQuantity :: [Rule]
+ruleAQuantity = map go quantities
+  where
+    go :: (Text, String, TQuantity.Unit) -> Rule
+    go (name, regexPattern, u) = Rule
+      { name = name
+      , pattern = [ regex ("een? " ++ regexPattern) ]
+      , prod = \case
+        (Token RegexMatch (GroupMatch (match:_)):
+         _) -> Just . Token Quantity $ quantity u $ getValue match 1
+        _ -> Nothing
+      }
+
+ruleQuantityOfProduct :: Rule
+ruleQuantityOfProduct = Rule
+  { name = "<quantity> product"
+  , pattern =
+    [ dimension Quantity
+    , regex "(\\w+)"
+    ]
+  , prod = \case
+    (Token Quantity qd:Token RegexMatch (GroupMatch (product:_)):_) ->
+      Just . Token Quantity $ withProduct product qd
+    _ -> Nothing
+  }
+
+rulePrecision :: Rule
+rulePrecision = Rule
+    { name = "ongeveer|plm|plusminus <quantity>"
+    , pattern =
+      [ regex "\\~|precies|exact|ongeveer|bijna|ongeveer"
+      , dimension Quantity
+      ]
+      , prod = \case
+        (_:token:_) -> Just token
+        _ -> Nothing
+  }
+
+ruleIntervalBetweenNumeral :: Rule
+ruleIntervalBetweenNumeral = Rule
+    { name = "tussen|van <numeral> en|tot <quantity>"
+    , pattern =
+      [ regex "tussen|van"
+      , Predicate isPositive
+      , regex "tot|en"
+      , Predicate isSimpleQuantity
+      ]
+    , prod = \case
+        (_:
+         Token Numeral NumeralData{TNumeral.value = from}:
+         _:
+         Token Quantity QuantityData{TQuantity.value = Just to
+                                    , TQuantity.unit = Just u
+                                    , TQuantity.aproduct = Nothing}:
+         _) | from < to ->
+          Just . Token Quantity . withInterval (from, to) $ unitOnly u
+        _ -> Nothing
+    }
+
+ruleIntervalBetween :: Rule
+ruleIntervalBetween = Rule
+    { name = "tussen|van <quantity> tot|en <quantity>"
+    , pattern =
+      [ regex "tussen|van"
+      , Predicate isSimpleQuantity
+      , regex "en|tot"
+      , Predicate isSimpleQuantity
+      ]
+    , prod = \case
+        (_:
+         Token Quantity QuantityData{TQuantity.value = Just from
+                                    , TQuantity.unit = Just u1
+                                    , TQuantity.aproduct = Nothing}:
+         _:
+         Token Quantity QuantityData{TQuantity.value = Just to
+                                    , TQuantity.unit = Just u2
+                                    , TQuantity.aproduct = Nothing}:
+         _) | from < to && u1 == u2 ->
+          Just . Token Quantity . withInterval (from, to) $ unitOnly u1
+        _ -> Nothing
+    }
+
+ruleIntervalNumeralDash :: Rule
+ruleIntervalNumeralDash = Rule
+    { name = "<numeral> - <quantity>"
+    , pattern =
+      [ Predicate isPositive
+      , regex "\\-"
+      , Predicate isSimpleQuantity
+      ]
+    , prod = \case
+        (Token Numeral NumeralData{TNumeral.value = from}:
+         _:
+         Token Quantity QuantityData{TQuantity.value = Just to
+                                    , TQuantity.unit = Just u
+                                    , TQuantity.aproduct = Nothing}:
+         _) | from < to ->
+           Just . Token Quantity . withInterval (from, to) $ unitOnly u
+        _ -> Nothing
+    }
+
+ruleIntervalDash :: Rule
+ruleIntervalDash = Rule
+    { name = "<quantity> - <quantity>"
+    , pattern =
+      [ Predicate isSimpleQuantity
+      , regex "\\-"
+      , Predicate isSimpleQuantity
+      ]
+    , prod = \case
+        (Token Quantity QuantityData{TQuantity.value = Just from
+                                    , TQuantity.unit = Just u1
+                                    , TQuantity.aproduct = Nothing}:
+         _:
+         Token Quantity QuantityData{TQuantity.value = Just to
+                                    , TQuantity.unit = Just u2
+                                    , TQuantity.aproduct = Nothing}:
+         _) | from < to && u1 == u2 ->
+          Just . Token Quantity . withInterval (from, to) $ unitOnly u1
+        _ -> Nothing
+    }
+
+
+
+ruleIntervalMax :: Rule
+ruleIntervalMax = Rule
+    { name = "minder dan/hoogstens/op zijn hoogst/maximaal/hooguit <quantity>"
+    , pattern =
+      [ regex "minder dan|hoogstens|hooguit|maximaal|op zijn hoogst"
+      , Predicate isSimpleQuantity
+      ]
+    , prod = \case
+        (_:
+         Token Quantity QuantityData{TQuantity.value = Just to
+                                    , TQuantity.unit = Just u
+                                    , TQuantity.aproduct = Nothing}:
+         _) -> Just . Token Quantity . withMax to $ unitOnly u
+        _ -> Nothing
+    }
+
+ruleIntervalMin :: Rule
+ruleIntervalMin = Rule
+  { name = "meer dan/minstens/op zijn minst <quantity>"
+  , pattern =
+      [ regex "meer dan|minstens|minimaal|op zijn minst|minder dan"
+      , Predicate isSimpleQuantity
+      ]
+    , prod = \case
+        (_:
+         Token Quantity QuantityData{TQuantity.value = Just from
+                                    , TQuantity.unit = Just u
+                                    , TQuantity.aproduct = Nothing}:
+         _) -> Just . Token Quantity . withMin from $ unitOnly u
+        _ -> Nothing
+    }
+rules :: [Rule]
+rules =
+  [ ruleQuantityOfProduct
+  , ruleIntervalMin
+  , ruleIntervalMax
+  , ruleIntervalBetweenNumeral
+  , ruleIntervalBetween
+  , ruleIntervalNumeralDash
+  , ruleIntervalDash
+  , rulePrecision
+  ]
+  ++ ruleNumeralQuantities
+  ++ ruleAQuantity

--- a/Duckling/Rules/NL.hs
+++ b/Duckling/Rules/NL.hs
@@ -24,6 +24,7 @@ import qualified Duckling.Distance.NL.Rules as Distance
 import qualified Duckling.Duration.NL.Rules as Duration
 import qualified Duckling.Numeral.NL.Rules as Numeral
 import qualified Duckling.Ordinal.NL.Rules as Ordinal
+import qualified Duckling.Quantity.NL.Rules as Quantity
 import qualified Duckling.Time.NL.Rules as Time
 import qualified Duckling.Time.NL.BE.Rules as TimeBE
 import qualified Duckling.Time.NL.NL.Rules as TimeNL
@@ -48,7 +49,7 @@ langRules (This Email) = []
 langRules (This Numeral) = Numeral.rules
 langRules (This Ordinal) = Ordinal.rules
 langRules (This PhoneNumber) = []
-langRules (This Quantity) = []
+langRules (This Quantity) = Quantity.rules
 langRules (This RegexMatch) = []
 langRules (This Temperature) = []
 langRules (This Time) = Time.rules

--- a/Duckling/Volume/NL/Corpus.hs
+++ b/Duckling/Volume/NL/Corpus.hs
@@ -25,20 +25,19 @@ corpus = (testContext {locale = makeLocale NL Nothing}, testOptions, allExamples
 allExamples :: [Example]
 allExamples = concat
   [ examples (simple Millilitre 250)
-             [ "250 mililiter"
+             [ "250 milliliter"
              , "250ml"
              , "250 ml"
              ]
   , examples (simple Litre 2)
              [ "2 liter"
+             , "2 liters"
              , "2l"
              , "2 l"
              ]
-  , examples (simple Gallon 3)
-             [ "3 gallon"
-             ]
   , examples (simple Hectolitre 3)
              [ "3 hectoliter"
+             , "3 hl"
              ]
   , examples (simple Litre 0.5)
              [ "halve liter"

--- a/Duckling/Volume/NL/Rules.hs
+++ b/Duckling/Volume/NL/Rules.hs
@@ -26,10 +26,9 @@ import qualified Duckling.Volume.Types as TVolume
 import qualified Duckling.Numeral.Types as TNumeral
 
 volumes :: [(Text, String, TVolume.Unit)]
-volumes = [ ("<latent vol> ml"    , "m(ili)?l(iter)?" , TVolume.Millilitre)
-          , ("<vol> hectoliters"  , "(hectoliter?)"   , TVolume.Hectolitre)
-          , ("<vol> liters"       , "l(iter)?"    , TVolume.Litre)
-          , ("<latent vol> gallon", "(gallon?)"   , TVolume.Gallon)
+volumes = [ ("<latent vol> ml"    , "m(illi)?l(iter)?" , TVolume.Millilitre)
+          , ("<vol> hl"           , "h(ecto)?l(iter)?"   , TVolume.Hectolitre)
+          , ("<vol> liters"       , "l(iter(s)?)?"    , TVolume.Litre)
           ]
 
 rulesVolumes :: [Rule]

--- a/duckling.cabal
+++ b/duckling.cabal
@@ -548,6 +548,8 @@ library
                      , Duckling.Quantity.KO.Rules
                      , Duckling.Quantity.MN.Corpus
                      , Duckling.Quantity.MN.Rules
+                     , Duckling.Quantity.NL.Corpus
+                     , Duckling.Quantity.NL.Rules
                      , Duckling.Quantity.PT.Corpus
                      , Duckling.Quantity.PT.Rules
                      , Duckling.Quantity.RO.Corpus
@@ -975,6 +977,7 @@ test-suite duckling-test
                      , Duckling.Quantity.KM.Tests
                      , Duckling.Quantity.KO.Tests
                      , Duckling.Quantity.MN.Tests
+                     , Duckling.Quantity.NL.Tests
                      , Duckling.Quantity.PT.Tests
                      , Duckling.Quantity.RO.Tests
                      , Duckling.Quantity.RU.Tests

--- a/tests/Duckling/Quantity/NL/Tests.hs
+++ b/tests/Duckling/Quantity/NL/Tests.hs
@@ -6,19 +6,19 @@
 -- of patent rights can be found in the PATENTS file in the same directory.
 
 
-module Duckling.Dimensions.NL
-  ( allDimensions
+module Duckling.Quantity.NL.Tests
+  ( tests
   ) where
 
-import Duckling.Dimensions.Types
+import Data.String
+import Prelude
+import Test.Tasty
 
-allDimensions :: [Some Dimension]
-allDimensions =
-  [ This Distance
-  , This Duration
-  , This Numeral
-  , This Ordinal
-  , This Quantity
-  , This Time
-  , This Volume
+import Duckling.Dimensions.Types
+import Duckling.Quantity.NL.Corpus
+import Duckling.Testing.Asserts
+
+tests :: TestTree
+tests = testGroup "NL Tests"
+  [ makeCorpusTest [This Quantity] corpus
   ]


### PR DESCRIPTION
* Added Quantity for NL; added g, kg, mg; only using 'pond' to map it to 500 g (pond in Dutch is 500g and not the same as the English pound). 'Ons' is mapped to 100g, is not the same as English ounce.
* Volume: removed gallon, it is not used in the Dutch language; fixed a typo in 'mililiter' (should be 'milliliter')