### PR TITLE
Time/NL Small bug fix

### DIFF
--- a/Duckling/Time/NL/Rules.hs
+++ b/Duckling/Time/NL/Rules.hs
@@ -711,7 +711,7 @@ ruleByTheEndOfTime :: Rule
 ruleByTheEndOfTime = Rule
   { name = "by the end of <time>"
   , pattern =
-    [ regex "tot (het)? einde (van)?|voor"
+    [ regex "tot (het)? einde (van)?"
     , dimension Time
     ]
   , prod = \tokens -> case tokens of


### PR DESCRIPTION
In the NL time module there's this bug where the following input

_"het is voor 5 personen"_ (english: _"it's for 5 people"_)

extracts a _time_ entity from it, instead of the expected _number_ entity.

This PR aims to fix that problem.
