### PR TITLE
Failing build bug fixed

### DIFF
--- a/duckling.cabal
+++ b/duckling.cabal
@@ -196,6 +196,7 @@ library
                      , Duckling.Dimensions.UK
                      , Duckling.Dimensions.VI
                      , Duckling.Dimensions.ZH
+                     , Duckling.Dimensions.SW
 
                      -- AmountOfMoney
                      , Duckling.AmountOfMoney.AR.Corpus


### PR DESCRIPTION
Fixed failing build by adding swahili dimension into the duckling.cabal file. The problem has been mentioned in issue [#316](https://github.com/facebook/duckling/issues/316).

Original error message:
`Undefined symbols for architecture x86_64: "_ducklingzm0zi1zi6zi1zmFuuoxNkK08bIA0dGJuhBV1_DucklingziDimensionsziSW_allDimensions_closure", referenced from: _se3Xu_info in libHSduckling-0.1.6.1-FuuoxNkK08bIA0dGJuhBV1.a(Dimensions.o) ld: symbol(s) not found for architecture x86_64 clang: error: linker command failed with exit code 1 (use -v to see invocation) gcc' failed in phase Linker'. (Exit code: 1)`