### PR TITLE
fix veintodós spelling

### DIFF
--- a/Duckling/Numeral/ES/Corpus.hs
+++ b/Duckling/Numeral/ES/Corpus.hs
@@ -42,6 +42,9 @@ allExamples = concat
              [ "veintiuno"
              , "veinte y uno"
              ]
+  , examples (NumeralValue 22)
+             [ "veintidós"
+             ]
   , examples (NumeralValue 23)
              [ "veintitrés"
              , "veinte y tres"

--- a/Duckling/Numeral/ES/Rules.hs
+++ b/Duckling/Numeral/ES/Rules.hs
@@ -138,6 +138,7 @@ sixteenToTwentyNineMap = HashMap.fromList
   , ( "veintiuno" , 21 )
   , ( "veintiuna" , 21 )
   , ( "veintidos" , 22 )
+  , ( "veintidós" , 22 )
   , ( "veintitrés" , 23 )
   , ( "veintitres" , 23 )
   , ( "veinticuatro" , 24 )
@@ -153,7 +154,7 @@ ruleNumeral5 :: Rule
 ruleNumeral5 = Rule
   { name = "number (16..19 21..29)"
   , pattern =
-    [ regex "(die(c|s)is(é|e)is|diecisiete|dieciocho|diecinueve|veintiun(o|a)|veintidos|veintitr(é|e)s|veinticuatro|veinticinco|veintis(é|e)is|veintisiete|veintiocho|veintinueve)"
+    [ regex "(die(c|s)is(é|e)is|diecisiete|dieciocho|diecinueve|veintiun(o|a)|veintid(o|ó)s|veintitr(é|e)s|veinticuatro|veinticinco|veintis(é|e)is|veintisiete|veintiocho|veintinueve|treinta)"
     ]
   , prod = \tokens -> case tokens of
       (Token RegexMatch (GroupMatch (match:_)):_) ->


### PR DESCRIPTION
This seems to have existed earlier but have been removed. The correct spelling seems to be with the accent though. 