### PR TITLE
 AmountOfMoney: match three letter currency codes beginning with C

### DIFF
--- a/Duckling/AmountOfMoney/EN/Corpus.hs
+++ b/Duckling/AmountOfMoney/EN/Corpus.hs
@@ -116,6 +116,22 @@ allExamples = concat
              , "GBP 3.01"
              , "3 GBP 1 pence"
              ]
+  , examples (simple CAD 3.03)
+             [ "CAD3.03"
+             , "CAD 3.03"
+             , "3 CAD 3 cents"
+             ]
+  , examples (simple CHF 3.04)
+             [ "CHF3.04"
+             , "CHF 3.04"
+             , "3 CHF 4 cents"
+             ]
+  , examples (simple CNY 3)
+             [ "CNY3"
+             , "CNY 3"
+             , "3 CNY"
+             , "3 yuan"
+             ]
   , examples (simple Unnamed 42)
              [ "42 bucks"
              , "around 42 bucks"

--- a/Duckling/AmountOfMoney/Rules.hs
+++ b/Duckling/AmountOfMoney/Rules.hs
@@ -127,7 +127,7 @@ ruleCurrencies :: Rule
 ruleCurrencies = Rule
   { name = "currencies"
   , pattern =
-    [ regex "(aed|aud|bgn|brl|byn|¢|c|cad|chf|cny|\\$|dinars?|dkk|dollars?|egp|(e|€)uro?s?|€|gbp|gel|\x20BE|hrk|idr|ils|₪|inr|iqd|jmd|jod|¥|jpy|lari|krw|kwd|lbp|mad|₮|mnt|tugriks?|myr|rm|nis|nok|nzd|£|pkr|pln|pta?s?|qar|₽|rs\\.?|riy?als?|ron|rub|rupees?|sar|sek|sgb|shekels?|thb|ttd|us(d|\\$)|vnd|yen|yuan|zar)"
+    [ regex "(aed|aud|bgn|brl|byn|¢|cad|chf|cny|c|\\$|dinars?|dkk|dollars?|egp|(e|€)uro?s?|€|gbp|gel|\x20BE|hrk|idr|ils|₪|inr|iqd|jmd|jod|¥|jpy|lari|krw|kwd|lbp|mad|₮|mnt|tugriks?|myr|rm|nis|nok|nzd|£|pkr|pln|pta?s?|qar|₽|rs\\.?|riy?als?|ron|rub|rupees?|sar|sek|sgb|shekels?|thb|ttd|us(d|\\$)|vnd|yen|yuan|zar)"
     ]
   , prod = \tokens -> case tokens of
       (Token RegexMatch (GroupMatch (match:_)):_) -> do


### PR DESCRIPTION
Closes #326 

All three letter currency codes beginning with the letter `C` are missed by the `currencies` regex. The regex will match `c` (meaning `cents`) and return, so `CAD`, `CHF` and `CNY` will never be matched.

This PR adds tests for all three failing currencies, and corrects the regex.