### PR TITLE
Update dependencies to latest version to make duckling compile with ghc 8.6.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ before_cache:
 
 matrix:
   include:
+    # crashes in travis because 2 versions of unix get installed and
     # when text-show tries to use TH the wrong one gets linked
     # - env: CABALVER=1.24 GHCVER=7.10.3 HAPPYVER=1.19.5 BUILD=cabal
     #   compiler: ": #GHC 7.10.3"

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,10 @@ before_cache:
 
 matrix:
   include:
+    # when text-show tries to use TH the wrong one gets linked
+    # - env: CABALVER=1.24 GHCVER=7.10.3 HAPPYVER=1.19.5 BUILD=cabal
+    #   compiler: ": #GHC 7.10.3"
+    #   addons: {apt: {packages: [cabal-install-1.24,ghc-7.10.3,happy-1.19.5], sources: [hvr-ghc]}}
     - env: CABALVER=1.24 GHCVER=8.0.2
       compiler: ": #GHC 8.0.2"
       addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.2,happy-1.19.5], sources: [hvr-ghc]}}

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,17 +13,15 @@ before_cache:
 
 matrix:
   include:
-    # crashes in travis because 2 versions of unix get installed and
-    # when text-show tries to use TH the wrong one gets linked
-    # - env: CABALVER=1.24 GHCVER=7.10.3 HAPPYVER=1.19.5 BUILD=cabal
-    #   compiler: ": #GHC 7.10.3"
-    #   addons: {apt: {packages: [cabal-install-1.24,ghc-7.10.3,happy-1.19.5], sources: [hvr-ghc]}}
     - env: CABALVER=1.24 GHCVER=8.0.2
       compiler: ": #GHC 8.0.2"
       addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.2,happy-1.19.5], sources: [hvr-ghc]}}
     - env: CABALVER=2.0 GHCVER=8.2.2
       compiler: ": #GHC 8.2.2"
       addons: {apt: {packages: [cabal-install-2.0,ghc-8.2.2,happy-1.19.5], sources: [hvr-ghc]}}
+    - env: CABALVER=2.0 GHCVER=8.6.3
+      compiler: ": #GHC 8.6.3"
+      addons: {apt: {packages: [cabal-install-2.0,ghc-8.6.3,happy-1.19.5], sources: [hvr-ghc]}}
 
 before_install:
  - unset CC

--- a/duckling.cabal
+++ b/duckling.cabal
@@ -1182,4 +1182,3 @@ executable duckling-expensive
 source-repository head
   type:     git
   location: https://github.com/facebook/duckling
-  

--- a/duckling.cabal
+++ b/duckling.cabal
@@ -24,7 +24,8 @@ stability:           alpha
 cabal-version:       >=1.10
 tested-with:
   GHC==8.0.2,
-  GHC==8.2.2
+  GHC==8.2.2,
+  GHC==8.6.3
 
 extra-source-files:    README.md
                      , PATENTS
@@ -795,7 +796,7 @@ library
                      , attoparsec            >= 0.13.1.0 && < 0.14
                      , aeson                 >= 0.11.3.0 && < 1.5
                      , bytestring            >= 0.10.6.0 && < 0.11
-                     , containers            >= 0.5.6.2 && < 0.6
+                     , containers            >= 0.5.6.2 && < 0.7
                      , deepseq               >= 1.4.1.1 && < 1.5
                      , dependent-sum         >= 0.3.2.2 && < 0.5
                      , extra                 >= 1.4.10 && < 1.7
@@ -803,8 +804,8 @@ library
                      , regex-base            >= 0.93.2 && < 0.94
                      , regex-pcre            >= 0.94.4 && < 0.95
                      , text                  >= 1.2.2.1 && < 1.3
-                     , text-show             >= 2.1.2 && < 3.7
-                     , time                  >= 1.5.0.1 && < 1.9
+                     , text-show             >= 2.1.2 && < 3.8
+                     , time                  >= 1.5.0.1 && < 2
                      , timezone-series       >= 0.1.5.1 && < 0.2
                      , unordered-containers  >= 0.2.7.2 && < 0.3
   default-language:    Haskell2010
@@ -820,7 +821,7 @@ test-suite duckling-test
                      , text
                      , time
                      , unordered-containers
-                     , tasty                 >= 0.11.1 && < 0.12
+                     , tasty                 >= 0.11.1 && < 1.3
                      , tasty-hunit           >= 0.9.2 && < 1.0
   other-modules:       Duckling.Tests
                      , Duckling.Testing.Asserts
@@ -1095,7 +1096,7 @@ executable duckling-regen-exe
                      , Duckling.Ranking.Generate
   build-depends:       duckling
                      , base
-                     , haskell-src-exts      >= 1.18 && < 1.20
+                     , haskell-src-exts      >= 1.18 && < 1.30
                      , text
                      , unordered-containers
   default-language:    Haskell2010
@@ -1114,7 +1115,7 @@ executable duckling-example-exe
                      , extra
                      , filepath              >= 1.4.0.0 && < 1.5
                      , snap-core             >= 1.0.2.0 && < 1.1
-                     , snap-server           >= 1.0.1.1 && < 1.1
+                     , snap-server           >= 1.0.1.1 && < 1.2
                      , text
                      , text-show
                      , time

--- a/duckling.cabal
+++ b/duckling.cabal
@@ -1182,3 +1182,4 @@ executable duckling-expensive
 source-repository head
   type:     git
   location: https://github.com/facebook/duckling
+  


### PR DESCRIPTION
I reviewed all outdated dependencies, there are 2 or 3 with minor breaking changes but none of them affect duckling.