### PR TITLE
Improve Docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+.stack-work

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,37 @@
-FROM haskell:8
+FROM haskell:8 AS builder
 
-RUN git clone https://github.com/facebook/duckling.git
+RUN apt-get update -qq && \
+  apt-get install -qq -y libpcre3 libpcre3-dev build-essential --fix-missing --no-install-recommends && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN mkdir /log
 
 WORKDIR /duckling
 
-RUN apt-get update
-
-RUN apt-get install -qq -y libpcre3 libpcre3-dev build-essential --fix-missing --no-install-recommends
+ADD stack.yaml .
 
 RUN stack setup
+
+ADD . .
+
 # NOTE:`stack build` will use as many cores as are available to build
 # in parallel. However, this can cause OOM issues as the linking step
 # in GHC can be expensive. If the build fails, try specifying the
 # '-j1' flag to force the build to run sequentially.
-RUN stack build
+RUN stack install
 
-ENTRYPOINT stack exec duckling-example-exe
+FROM debian:stretch
+
+ENV LANG C.UTF-8
+
+RUN apt-get update -qq && \
+  apt-get install -qq -y libpcre3 libgmp10 --no-install-recommends && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+COPY --from=builder /root/.local/bin/duckling-example-exe /usr/local/bin/
+
+EXPOSE 8000
+
+CMD ["duckling-example-exe", "-p", "8000"]


### PR DESCRIPTION
* Reduces size of final image from 5GB to 130MB
* Builds any checkout (not locked to the master)
* Doesn't run stack on CMD (executes static build of Duckling instead)