### PR TITLE
Add support for larger spelled-out Danish ordinals

### DIFF
--- a/Duckling/Numeral/DA/Rules.hs
+++ b/Duckling/Numeral/DA/Rules.hs
@@ -142,14 +142,16 @@ rulePowersOfTen :: Rule
 rulePowersOfTen = Rule
   { name = "powers of tens"
   , pattern =
-    [ regex "(hundrede?|tusinde?|million(er)?)"
+    [ regex "(hundrede?|tohundrede|tusinde?|totusinde|million(er)?)"
     ]
   , prod = \tokens -> case tokens of
       (Token RegexMatch (GroupMatch (match:_)):_) -> case Text.toLower match of
         "hundred"   -> double 1e2 >>= withGrain 2 >>= withMultipliable
         "hundrede"  -> double 1e2 >>= withGrain 2 >>= withMultipliable
+        "tohundrede"  -> double (2 * 1e2) >>= withGrain 2 >>= withMultipliable
         "tusind"    -> double 1e3 >>= withGrain 3 >>= withMultipliable
         "tusinde"   -> double 1e3 >>= withGrain 3 >>= withMultipliable
+        "totusinde"   -> double (2 * 1e3) >>= withGrain 3 >>= withMultipliable
         "million"   -> double 1e6 >>= withGrain 6 >>= withMultipliable
         "millioner" -> double 1e6 >>= withGrain 6 >>= withMultipliable
         _           -> Nothing

--- a/Duckling/Ordinal/DA/Corpus.hs
+++ b/Duckling/Ordinal/DA/Corpus.hs
@@ -23,9 +23,24 @@ corpus :: Corpus
 corpus = (testContext {locale = makeLocale DA Nothing}, testOptions, allExamples)
 
 allExamples :: [Example]
-allExamples =
-  examples (OrdinalData 4)
-           [ "4."
-           , "fjerde"
-           , "Fjerde"
-           ]
+allExamples = concat
+  [ examples (OrdinalData 4)
+             [ "4."
+             , "fjerde"
+             , "Fjerde"
+             ]
+  , examples (OrdinalData 41)
+             [ "enogfyrrende"
+             ]
+  , examples (OrdinalData 78)
+             [ "otteoghalvfjerdsindstyvende"
+             ]
+  , examples (OrdinalData 263)
+             [ "to hundrede og treogtresindstyvende"
+             , "tohundrede og treogtresindstyvende"
+             ]
+  , examples (OrdinalData 70)             
+             [ "halvfjerdsende",
+               "halvfjerdsindstyvende"
+             ]
+  ]

--- a/Duckling/Ordinal/DA/Rules.hs
+++ b/Duckling/Ordinal/DA/Rules.hs
@@ -8,6 +8,7 @@
 
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE LambdaCase #-}
 
 module Duckling.Ordinal.DA.Rules
   ( rules ) where
@@ -18,15 +19,18 @@ import Data.String
 
 import Duckling.Dimensions.Types
 import Duckling.Numeral.Helpers (parseInt)
+import Duckling.Numeral.Types (NumeralData (..), getIntValue)
+import qualified Duckling.Numeral.Types as TNumeral
 import Duckling.Ordinal.Helpers
+import Duckling.Ordinal.Types (OrdinalData (..))
 import Duckling.Regex.Types
 import Duckling.Types
 
 ruleOrdinalsFirstst :: Rule
 ruleOrdinalsFirstst = Rule
-  { name = "ordinals (first..31st)"
+  { name = "ordinals (first..19st)"
   , pattern =
-    [ regex "(første|anden|tredje|fjerde|femte|sjette|syvende|ottende|niende|tiende|elfte|tolvte|trettende|fjortende|femtende|sekstende|syttende|attende|nittende|tyvende|tenogtyvende|toogtyvende|treogtyvende|fireogtyvende|femogtyvende|seksogtyvende|syvogtyvende|otteogtyvende|niogtyvende|tredivte|enogtredivte)"
+    [ regex "(første|anden|tredje|fjerde|femte|sjette|syvende|ottende|niende|tiende|elfte|tolvte|trettende|fjortende|femtende|sekstende|syttende|attende|nittende)"
     ]
   , prod = \tokens -> case tokens of
       (Token RegexMatch (GroupMatch (match:_)):_) -> case Text.toLower match of
@@ -65,6 +69,75 @@ ruleOrdinalsFirstst = Rule
       _ -> Nothing
   }
 
+ruleSpelledOutOrdinals :: Rule
+ruleSpelledOutOrdinals = Rule
+  { name = "ordinals, 20 to 99, spelled-out"
+  , pattern =
+    [ regex (concat ["((?:en|to|tre|fire|fem|seks|syv|otte|ni)og)?", 
+                     "(tyvende",
+                     "|tredivte",
+                     "|fyrr(?:etyv)?ende",
+                     "|halvtreds(?:indstyv)?ende",
+                     "|tres(?:indstyv|s)?ende",
+                     "|halvfjerds(?:indstyv)?ende",
+                     "|firs(?:indstyv)?ende",
+                     "|halvfems(?:indstyv)?ende)"])
+    ]
+  , prod = \case 
+    (Token RegexMatch (GroupMatch (ones:tens:_)):_) -> do
+      oneVal <- case Text.toLower ones of
+                  "" -> Just 0
+                  "enog" -> Just 1
+                  "toog" -> Just 2
+                  "treog" -> Just 3
+                  "fireog" -> Just 4
+                  "femog" -> Just 5
+                  "seksog" -> Just 6
+                  "syvog" -> Just 7
+                  "otteog" -> Just 8
+                  "niog" -> Just 9
+                  _ -> Nothing
+      tenVal <- case Text.toLower tens of
+                  "tyvende" -> Just 20
+                  "tredivte" -> Just 30
+                  "fyrrende" -> Just 40
+                  "fyrretyvende" -> Just 40
+                  "halvtredsende" -> Just 50
+                  "halvtredsindstyvende" -> Just 50
+                  "tressende" -> Just 60
+                  "tresindstyvende" -> Just 60
+                  "halvfjerdsende" -> Just 70
+                  "halvfjerdsindstyvende" -> Just 70
+                  "firsende" -> Just 80
+                  "firsindsstyvende" -> Just 80
+                  "halvfemsende" -> Just 90
+                  "halvfemsindstyvende" -> Just 90
+                  _ -> Nothing
+      Just $ ordinal (oneVal + tenVal) 
+    _ -> Nothing
+        
+  }
+
+ruleSpelledOutBigOrdinals :: Rule
+ruleSpelledOutBigOrdinals = Rule
+  { name = "ordinals, above 99, spelled out"
+  , pattern = 
+    [ Predicate (\case
+                  Token Numeral NumeralData {TNumeral.value=numnum} | (numnum > 99) -> True
+                  _ -> False)
+    , regex " og "
+    , Predicate (\case
+                  Token Ordinal (OrdinalData ordnum) -> True
+                  _ -> False)  
+    ]
+  , prod = \case
+      (Token Numeral NumeralData {TNumeral.value=maybenumnum}):_:(Token Ordinal (OrdinalData ordnum)):_ ->
+            case getIntValue(maybenumnum) of
+              Just numnum -> Just $ ordinal (numnum + ordnum)
+              Nothing -> Nothing
+      _ -> Nothing
+  }
+  
 ruleOrdinalDigits :: Rule
 ruleOrdinalDigits = Rule
   { name = "ordinal (digits)"
@@ -82,4 +155,6 @@ rules :: [Rule]
 rules =
   [ ruleOrdinalDigits
   , ruleOrdinalsFirstst
+  , ruleSpelledOutOrdinals
+  , ruleSpelledOutBigOrdinals
   ]

--- a/Duckling/Ranking/Classifiers/DA_XX.hs
+++ b/Duckling/Ranking/Classifiers/DA_XX.hs
@@ -277,7 +277,7 @@ classifiers
                                  HashMap.fromList
                                    [("ordinal (digits)quarter (grain)", -1.252762968495368),
                                     ("quarter", -0.8472978603872037),
-                                    ("ordinals (first..31st)quarter (grain)", -1.252762968495368)],
+                                    ("ordinals (first..19st)quarter (grain)", -1.252762968495368)],
                                n = 2},
                    koData =
                      ClassData{prior = -0.6931471805599453,
@@ -286,7 +286,7 @@ classifiers
                                  HashMap.fromList
                                    [("ordinal (digits)quarter (grain)", -1.252762968495368),
                                     ("quarter", -0.8472978603872037),
-                                    ("ordinals (first..31st)quarter (grain)", -1.252762968495368)],
+                                    ("ordinals (first..19st)quarter (grain)", -1.252762968495368)],
                                n = 2}}),
        ("intersect",
         Classifier{okData =
@@ -420,12 +420,12 @@ classifiers
                                likelihoods =
                                  HashMap.fromList
                                    [("daymonth", -1.7346010553881064),
-                                    ("ordinals (first..31st)week (grain)October",
+                                    ("ordinals (first..19st)week (grain)intersect",
                                      -1.7346010553881064),
-                                    ("ordinals (first..31st)week (grain)intersect",
+                                    ("ordinals (first..19st)week (grain)October",
                                      -1.7346010553881064),
                                     ("weekmonth", -1.2237754316221157),
-                                    ("ordinals (first..31st)day (grain)October",
+                                    ("ordinals (first..19st)day (grain)October",
                                      -1.7346010553881064)],
                                n = 6},
                    koData =
@@ -567,7 +567,7 @@ classifiers
                      ClassData{prior = 0.0, unseen = -2.0794415416798357,
                                likelihoods =
                                  HashMap.fromList
-                                   [("ordinals (first..31st)quarter (grain)year",
+                                   [("ordinals (first..19st)quarter (grain)year",
                                      -1.252762968495368),
                                     ("quarteryear", -0.8472978603872037),
                                     ("ordinal (digits)quarter (grain)year", -1.252762968495368)],
@@ -625,9 +625,9 @@ classifiers
                                likelihoods =
                                  HashMap.fromList
                                    [("daymonth", -0.8938178760220964),
-                                    ("ordinals (first..31st)TuesdayOctober", -1.9924301646902063),
-                                    ("ordinals (first..31st)Tuesdayintersect", -1.9924301646902063),
-                                    ("ordinals (first..31st)Wednesdayintersect",
+                                    ("ordinals (first..19st)Tuesdayintersect", -1.9924301646902063),
+                                    ("ordinals (first..19st)TuesdayOctober", -1.9924301646902063),
+                                    ("ordinals (first..19st)Wednesdayintersect",
                                      -1.4816045409242156)],
                                n = 8},
                    koData =
@@ -636,8 +636,8 @@ classifiers
                                likelihoods =
                                  HashMap.fromList
                                    [("daymonth", -0.9444616088408514),
-                                    ("ordinals (first..31st)WednesdayOctober", -1.2809338454620642),
-                                    ("ordinals (first..31st)TuesdaySeptember", -1.791759469228055)],
+                                    ("ordinals (first..19st)WednesdayOctober", -1.2809338454620642),
+                                    ("ordinals (first..19st)TuesdaySeptember", -1.791759469228055)],
                                n = 6}}),
        ("the <day-of-month> (non ordinal)",
         Classifier{okData =
@@ -647,15 +647,6 @@ classifiers
                    koData =
                      ClassData{prior = -infinity, unseen = -0.6931471805599453,
                                likelihoods = HashMap.fromList [], n = 0}}),
-       ("ordinals (first..31st)",
-        Classifier{okData =
-                     ClassData{prior = -5.406722127027582e-2,
-                               unseen = -2.995732273553991,
-                               likelihoods = HashMap.fromList [("", 0.0)], n = 18},
-                   koData =
-                     ClassData{prior = -2.9444389791664407,
-                               unseen = -1.0986122886681098,
-                               likelihoods = HashMap.fromList [("", 0.0)], n = 1}}),
        ("April",
         Classifier{okData =
                      ClassData{prior = 0.0, unseen = -1.6094379124341003,
@@ -708,7 +699,7 @@ classifiers
                                unseen = -3.258096538021482,
                                likelihoods =
                                  HashMap.fromList
-                                   [("ordinals (first..31st)March", -1.8325814637483102),
+                                   [("ordinals (first..19st)March", -1.8325814637483102),
                                     ("ordinal (digits)February", -1.8325814637483102),
                                     ("month", -0.8209805520698302),
                                     ("ordinal (digits)March", -1.6094379124341003)],
@@ -718,7 +709,7 @@ classifiers
                                unseen = -2.0794415416798357,
                                likelihoods =
                                  HashMap.fromList
-                                   [("ordinals (first..31st)April", -1.252762968495368),
+                                   [("ordinals (first..19st)April", -1.252762968495368),
                                     ("month", -1.252762968495368)],
                                n = 1}}),
        ("numbers prefix with -, negative or minus",
@@ -803,7 +794,7 @@ classifiers
                      ClassData{prior = 0.0, unseen = -2.3978952727983707,
                                likelihoods =
                                  HashMap.fromList
-                                   [("ordinals (first..31st)", -1.2039728043259361),
+                                   [("ordinals (first..19st)", -1.2039728043259361),
                                     ("ordinal (digits)", -0.35667494393873245)],
                                n = 8},
                    koData =
@@ -879,6 +870,15 @@ classifiers
                    koData =
                      ClassData{prior = -infinity, unseen = -0.6931471805599453,
                                likelihoods = HashMap.fromList [], n = 0}}),
+       ("ordinals (first..19st)",
+        Classifier{okData =
+                     ClassData{prior = -5.406722127027582e-2,
+                               unseen = -2.995732273553991,
+                               likelihoods = HashMap.fromList [("", 0.0)], n = 18},
+                   koData =
+                     ClassData{prior = -2.9444389791664407,
+                               unseen = -1.0986122886681098,
+                               likelihoods = HashMap.fromList [("", 0.0)], n = 1}}),
        ("about <time-of-day>",
         Classifier{okData =
                      ClassData{prior = -0.6931471805599453,
@@ -1545,8 +1545,8 @@ classifiers
                      ClassData{prior = 0.0, unseen = -2.3978952727983707,
                                likelihoods =
                                  HashMap.fromList
-                                   [("ordinals (first..31st)April", -1.6094379124341003),
-                                    ("ordinals (first..31st)March", -1.6094379124341003),
+                                   [("ordinals (first..19st)April", -1.6094379124341003),
+                                    ("ordinals (first..19st)March", -1.6094379124341003),
                                     ("month", -0.916290731874155),
                                     ("ordinal (digits)March", -1.6094379124341003)],
                                n = 3},

--- a/Duckling/Ranking/Classifiers/IT_XX.hs
+++ b/Duckling/Ranking/Classifiers/IT_XX.hs
@@ -320,10 +320,10 @@ classifiers
                                unseen = -4.31748811353631,
                                likelihoods =
                                  HashMap.fromList
-                                   [("<integer> (latent time-of-day)", -0.9718605830289658),
+                                   [("<integer> (latent time-of-day)", -0.9718605830289657),
                                     ("intersect by \"di\", \"della\", \"del\"", -3.20545280453606),
                                     ("day", -2.3581549441488563), ("Lunedi", -3.6109179126442243),
-                                    ("hour", -0.9718605830289658),
+                                    ("hour", -0.9718605830289657),
                                     ("two time tokens separated by `di`", -3.20545280453606),
                                     ("Domenica", -3.6109179126442243)],
                                n = 33}}),


### PR DESCRIPTION
Adds support for larger spelled-out Danish ordinal number expressions, like
treoghalvfemsindstyvende (93rd) 
or
tohundrede og femogfyrrende (245th)