### PR TITLE
Time.FR > add rule for years in twentieth centry

### DIFF
--- a/Duckling/Time/FR/Corpus.hs
+++ b/Duckling/Time/FR/Corpus.hs
@@ -216,6 +216,7 @@ allExamples = concat
   , examples (datetime (1974, 10, 31, 0, 0, 0) Day)
              [ "31/10/1974"
              , "31/10/74"
+             , "31 octobre 74"
              ]
   , examples (datetime (2013, 2, 18, 0, 0, 0) Day)
              [ "lundi prochain"

--- a/Duckling/Time/FR/Rules.hs
+++ b/Duckling/Time/FR/Rules.hs
@@ -1639,6 +1639,20 @@ ruleYear = Rule
       _ -> Nothing
   }
 
+ruleVingtiemeSiecleYear :: Rule
+ruleVingtiemeSiecleYear = Rule
+  { name = "year"
+  , pattern =
+    [ Predicate $ isIntegerBetween 40 99
+    ]
+  , prod = \tokens -> case tokens of
+      (token:_) -> do
+        n <- getIntValue token
+        realYear <- Just (1900 + n)
+        tt $ year realYear
+      _ -> Nothing
+  }
+
 ruleMaintenant :: Rule
 ruleMaintenant = Rule
   { name = "maintenant"
@@ -2070,6 +2084,7 @@ rules =
   , ruleDbutDAnnee
   , rulePlusTard
   , rulePlusTardPartofday
+  , ruleVingtiemeSiecleYear
   ]
   ++ ruleMonths
   ++ ruleDaysOfWeek


### PR DESCRIPTION
In Time.FR, add support for birthdates like "15 juin 72"

resolves #347 