### PR TITLE
skip logfile creation if no logging

### DIFF
--- a/exe/ExampleMain.hs
+++ b/exe/ExampleMain.hs
@@ -41,19 +41,27 @@ createIfMissing f = do
   exists <- doesFileExist f
   unless exists $ writeFile f ""
 
-setupLogs :: IO ()
-setupLogs = do
-  createDirectoryIfMissing False "log"
-  createIfMissing "log/error.log"
-  createIfMissing "log/access.log"
+shouldLog :: Maybe ConfigLog -> Bool
+shouldLog Nothing = False
+shouldLog (Just ConfigNoLog) = False
+shouldLog _ = True
+
+setupLogs :: Config a b -> IO ()
+setupLogs conf = do
+  let shouldLogErrors = shouldLog $ getErrorLog conf
+  let shouldLogAccesses = shouldLog $ getAccessLog conf
+
+  when (shouldLogErrors || shouldLogAccesses) $ createDirectoryIfMissing False "log"
+  when shouldLogErrors $ createIfMissing "log/error.log"
+  when shouldLogAccesses $ createIfMissing "log/access.log"
 
 main :: IO ()
 main = do
-  setupLogs
   tzs <- loadTimeZoneSeries "/usr/share/zoneinfo/"
   p <- lookupEnv "PORT"
   conf <- commandLineConfig $
     maybe defaultConfig (`setPort` defaultConfig) (readMaybe =<< p)
+  setupLogs conf
   httpServe conf $
     ifTop (writeBS "quack!") <|>
     route

--- a/exe/ExampleMain.hs
+++ b/exe/ExampleMain.hs
@@ -9,7 +9,7 @@
 
 import Control.Applicative hiding (empty)
 import Control.Arrow ((***))
-import Control.Monad (unless)
+import Control.Monad (unless, when)
 import Control.Monad.IO.Class
 import Data.Aeson
 import Data.ByteString (ByteString, empty)


### PR DESCRIPTION
**Motivation**
Currently the log files and the log directory for the server are always created, even if the logging is disabled. If duckling is used on OpenShift the file creation leads to errors if no volume mount is defined.

**Proposed Change**:
Only create log files / log directory if the logging is enabled.

