### PR TITLE
[EN] Fixes ambiguous parses when both ruleNegative and ruleMultiply apply

### DIFF
--- a/Duckling/Numeral/EN/Corpus.hs
+++ b/Duckling/Numeral/EN/Corpus.hs
@@ -141,6 +141,12 @@ allExamples = concat
              , "-1200K"
              , "-.0012G"
              ]
+  , examples (NumeralValue (-3200000))
+             [
+               "-3,200,000",
+               "-3200000",
+               "minus three million two hundred thousand"
+             ]
   , examples (NumeralValue 122)
              [ "one twenty two"
              , "ONE TwentY tWO"

--- a/Duckling/Numeral/EN/Rules.hs
+++ b/Duckling/Numeral/EN/Rules.hs
@@ -314,7 +314,7 @@ ruleMultiply :: Rule
 ruleMultiply = Rule
   { name = "compose by multiplication"
   , pattern =
-    [ dimension Numeral
+    [ Predicate isPositive
     , Predicate isMultipliable
     ]
   , prod = \tokens -> case tokens of

--- a/duckling.cabal
+++ b/duckling.cabal
@@ -815,7 +815,6 @@ library
 test-suite duckling-test
   type:                exitcode-stdio-1.0
   main-is:             TestMain.hs
-  ghc-options:         -main-is TestMain
   hs-source-dirs:      tests
   build-depends:       duckling
                      , base

--- a/tests/TestMain.hs
+++ b/tests/TestMain.hs
@@ -4,7 +4,7 @@
 -- This source code is licensed under the BSD-style license found in the
 -- LICENSE file in the root directory of this source tree.
 
-module TestMain where
+module Main where
 
 import Data.String
 import Test.Tasty


### PR DESCRIPTION
I noticed two ambiguous parses would occur when both ruleNegative and ruleMultiply would apply.

For example: "minus three million two hundred thousand"

```
*Duckling.Debug> debug (makeLocale EN Nothing) "minus three million two hundred thousand" [This Numeral]
compose by multiplication (minus three million two hundred thousand)
-- negative numbers (minus three million two hundred)
-- -- regex (minus)
-- -- intersect 2 numbers (three million two hundred)
-- -- -- compose by multiplication (three million)
-- -- -- -- integer (0..19) (three)
-- -- -- -- -- regex (three)
-- -- -- -- powers of tens (million)
-- -- -- -- -- regex (million)
-- -- -- compose by multiplication (two hundred)
-- -- -- -- integer (0..19) (two)
-- -- -- -- -- regex (two)
-- -- -- -- powers of tens (hundred)
-- -- -- -- -- regex (hundred)
-- powers of tens (thousand)
-- -- regex (thousand)
negative numbers (minus three million two hundred thousand)
-- regex (minus)
-- intersect 2 numbers (three million two hundred thousand)
-- -- compose by multiplication (three million)
-- -- -- integer (0..19) (three)
-- -- -- -- regex (three)
-- -- -- powers of tens (million)
-- -- -- -- regex (million)
-- -- compose by multiplication (two hundred thousand)
-- -- -- compose by multiplication (two hundred)
-- -- -- -- integer (0..19) (two)
-- -- -- -- -- regex (two)
-- -- -- -- powers of tens (hundred)
-- -- -- -- -- regex (hundred)
-- -- -- powers of tens (thousand)
-- -- -- -- regex (thousand)
```

This PR fixes this ambiguity and Duckling will only return the second (correct) parse.