### PR TITLE
Fix typo in PL Duration Rules

### DIFF
--- a/Duckling/Duration/PL/Rules.hs
+++ b/Duckling/Duration/PL/Rules.hs
@@ -95,7 +95,7 @@ ruleAboutDuration :: Rule
 ruleAboutDuration = Rule
   { name = "about <duration>"
   , pattern =
-    [ regex "(oko(l|ł)o|miej wi(ę|e)cej|jakie(s|ś))"
+    [ regex "(oko(l|ł)o|mniej wi(ę|e)cej|jakie(s|ś))"
     , dimension Duration
     ]
   , prod = \tokens -> case tokens of


### PR DESCRIPTION
'miej' in Polish is the imperative form of the verb 'mieć' (to have). "mniej więcej" means "more or less" and it was the intention here.