### PR TITLE
Fix the issue with aeson and cabal.

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-9.10
+resolver: lts-13.11
 
 packages:
 - '.'
@@ -8,3 +8,5 @@ extra-deps: []
 flags: {}
 
 extra-package-dbs: []
+
+allow-newer: true


### PR DESCRIPTION
There is an issue, that happens on macOS and shows error: `can't load .so/.DLL`
and happens `--  While building package aeson-1.1.2.0 using:`
in `.stack/setup-exe-cache/x86_64-osx/Cabal-simple_mPHDZzAJ_1.24.2.0_ghc[...]` file.

Apparently it is due to some incompatibilities between compiler libraries and system libraries related to date/time, so It wouldn't be cabal neither stack, it is the actual compiler version that is failing.
I tried to fix it in many ways, even reinstalling macOS, but nothing seems to help except moving to newer version of lts.
Allow newer version is needed so dependencies in .cabal file are satisfied.
related issue: #446 
