### PR TITLE
Fixed a problem with parsing fractional minutes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .stack-work/
 log/
 .idea/
+*.lock

--- a/Duckling/Duration/EN/Corpus.hs
+++ b/Duckling/Duration/EN/Corpus.hs
@@ -130,4 +130,10 @@ allExamples = concat
               ]
   , examples (DurationData 3630 Second)
               [ "an hour and 30 seconds"]
+  , examples (DurationData 930 Second)
+              [ "15.5 minutes"
+              , "15.5 minute"
+              , "15.5 mins"
+              , "15.5 min"
+              ]
   ]

--- a/Duckling/Duration/EN/Corpus.hs
+++ b/Duckling/Duration/EN/Corpus.hs
@@ -120,4 +120,14 @@ allExamples = concat
              , "five and half min"
              , "5 and an half minute"
              ]
+  , examples (DurationData 105 Minute)
+              [ "an hour and 45 minutes"
+              , "one hour and 45 minutes"
+              ]
+  , examples (DurationData 90 Second)
+              [ "a minute and 30 seconds"
+              , "one minute and 30 seconds"
+              ]
+  , examples (DurationData 3630 Second)
+              [ "an hour and 30 seconds"]
   ]

--- a/Duckling/Duration/EN/Corpus.hs
+++ b/Duckling/Duration/EN/Corpus.hs
@@ -120,14 +120,4 @@ allExamples = concat
              , "five and half min"
              , "5 and an half minute"
              ]
-  , examples (DurationData 105 Minute)
-              [ "an hour and 45 minutes"
-              , "one hour and 45 minutes"
-              ]
-  , examples (DurationData 90 Second)
-              [ "a minute and 30 seconds"
-              , "one minute and 30 seconds"
-              ]
-  , examples (DurationData 3630 Second)
-              [ "an hour and 30 seconds"]
   ]

--- a/Duckling/Duration/EN/Rules.hs
+++ b/Duckling/Duration/EN/Rules.hs
@@ -240,9 +240,26 @@ ruleCompositeDuration = Rule
       _ -> Nothing
   }
 
+ruleCompositeDurationAnd :: Rule
+ruleCompositeDurationAnd = Rule
+  { name = "composite <duration> and <duration>"
+  , pattern =
+    [ dimension Duration
+    , regex ",|and"
+    , dimension Duration
+    ]
+  , prod = \case
+      (Token Duration DurationData{TDuration.value = v, TDuration.grain = g}:
+       _:
+       Token Duration dd@DurationData{TDuration.grain = dg}:
+       _) | g > dg -> Just . Token Duration $ duration g (v) <> dd
+      _ -> Nothing
+  }
+
 rules :: [Rule]
 rules =
-  [ ruleDurationQuarterOfAnHour
+  [ ruleCompositeDurationCommasAnd
+  , ruleDurationQuarterOfAnHour
   , ruleDurationHalfAnHourAbbrev
   , ruleDurationThreeQuartersOfAnHour
   , ruleDurationFortnight
@@ -257,5 +274,5 @@ rules =
   , ruleDurationPrecision
   , ruleNumeralQuotes
   , ruleCompositeDuration
-  , ruleCompositeDurationCommasAnd
+  , ruleCompositeDurationAnd
   ]

--- a/Duckling/Duration/EN/Rules.hs
+++ b/Duckling/Duration/EN/Rules.hs
@@ -240,26 +240,9 @@ ruleCompositeDuration = Rule
       _ -> Nothing
   }
 
-ruleCompositeDurationAnd :: Rule
-ruleCompositeDurationAnd = Rule
-  { name = "composite <duration> and <duration>"
-  , pattern =
-    [ dimension Duration
-    , regex ",|and"
-    , dimension Duration
-    ]
-  , prod = \case
-      (Token Duration DurationData{TDuration.value = v, TDuration.grain = g}:
-       _:
-       Token Duration dd@DurationData{TDuration.grain = dg}:
-       _) | g > dg -> Just . Token Duration $ duration g (v) <> dd
-      _ -> Nothing
-  }
-
 rules :: [Rule]
 rules =
-  [ ruleCompositeDurationCommasAnd
-  , ruleDurationQuarterOfAnHour
+  [ ruleDurationQuarterOfAnHour
   , ruleDurationHalfAnHourAbbrev
   , ruleDurationThreeQuartersOfAnHour
   , ruleDurationFortnight
@@ -274,5 +257,5 @@ rules =
   , ruleDurationPrecision
   , ruleNumeralQuotes
   , ruleCompositeDuration
-  , ruleCompositeDurationAnd
+  , ruleCompositeDurationCommasAnd
   ]

--- a/Duckling/Duration/EN/Rules.hs
+++ b/Duckling/Duration/EN/Rules.hs
@@ -256,6 +256,22 @@ ruleCompositeDurationAnd = Rule
       _ -> Nothing
   }
 
+ruleDurationDotNumeralMinutes :: Rule
+ruleDurationDotNumeralMinutes = Rule
+  { name = "number.number minutes"
+  , pattern =
+    [ regex "(\\d+)\\.(\\d+)"
+    , Predicate $ isGrain TG.Minute
+    ]
+  , prod = \case
+      (Token RegexMatch (GroupMatch (m:s:_)):_) -> do
+        mm <- parseInteger m
+        ss <- parseInteger s
+        let sden = 10 ^ Text.length s
+        Just . Token Duration $ secondsFromHourMixedFraction mm ss sden
+      _ -> Nothing
+  }
+
 rules :: [Rule]
 rules =
   [ ruleCompositeDurationCommasAnd
@@ -275,4 +291,5 @@ rules =
   , ruleNumeralQuotes
   , ruleCompositeDuration
   , ruleCompositeDurationAnd
+  , ruleDurationDotNumeralMinutes
   ]

--- a/Duckling/Duration/Helpers.hs
+++ b/Duckling/Duration/Helpers.hs
@@ -13,6 +13,7 @@ module Duckling.Duration.Helpers
   , isNatural
   , minutesFromHourMixedFraction
   , nPlusOneHalf
+  , secondsFromHourMixedFraction
   ) where
 
 import Prelude
@@ -49,3 +50,7 @@ nPlusOneHalf grain = case grain of
   TG.Month  -> Just . duration TG.Day    . (15+) . (30*)
   TG.Year   -> Just . duration TG.Month  . (6+)  . (12*)
   _         -> const Nothing
+
+secondsFromHourMixedFraction :: Integer -> Integer -> Integer -> DurationData
+secondsFromHourMixedFraction m s d =
+  duration TG.Second $ fromIntegral $ 60 * m + quot (s * 60) d

--- a/Duckling/Time/ES/Corpus.hs
+++ b/Duckling/Time/ES/Corpus.hs
@@ -9,6 +9,7 @@
 
 module Duckling.Time.ES.Corpus
   ( corpus
+    , latentCorpus
   ) where
 
 import Data.String
@@ -19,9 +20,22 @@ import Duckling.Resolve
 import Duckling.Time.Corpus
 import Duckling.TimeGrain.Types hiding (add)
 import Duckling.Testing.Types hiding (examples)
+import Duckling.Time.Types hiding (Month)
+
+context :: Context
+context = testContext {locale = makeLocale ES Nothing}
+
+latentCorpus :: Corpus
+latentCorpus = (context, testOptions {withLatent = True}, xs)
+  where
+    xs = concat
+      [ examples (datetime (2013, 2, 12, 13, 0, 0) Hour)
+                 [ "una hora"
+                 ]
+      ]
 
 corpus :: Corpus
-corpus = (testContext {locale = makeLocale ES Nothing}, testOptions, allExamples)
+corpus = (context, testOptions, allExamples)
 
 allExamples :: [Example]
 allExamples = concat

--- a/Duckling/Time/ES/Rules.hs
+++ b/Duckling/Time/ES/Rules.hs
@@ -866,7 +866,7 @@ ruleTimeofdayHoras = Rule
     ]
   , prod = \tokens -> case tokens of
       (Token Time td:_) ->
-        tt $ notLatent td
+        tt $ mkLatent td
       _ -> Nothing
   }
 

--- a/tests/Duckling/Time/ES/Tests.hs
+++ b/tests/Duckling/Time/ES/Tests.hs
@@ -19,4 +19,5 @@ import Duckling.Time.ES.Corpus
 tests :: TestTree
 tests = testGroup "ES Tests"
   [ makeCorpusTest [This Time] corpus
+    , makeCorpusTest [This Time] latentCorpus
   ]

--- a/tests/TestMain.hs
+++ b/tests/TestMain.hs
@@ -4,7 +4,7 @@
 -- This source code is licensed under the BSD-style license found in the
 -- LICENSE file in the root directory of this source tree.
 
-module TestMain where
+-- module TestMain where
 
 import Data.String
 import Test.Tasty


### PR DESCRIPTION
Current behavior
sentence with pattern "xxx.yyy minutes" parsed as yyy minutes. 

Expected behavior:
xxx.yyy minutes = 60*xxx+0.yyy*60 seconds

For example:
"15.5" minutes = 60*15+0.5*60 = 930 seconds