### PR TITLE
Fixed a problem with parsing the expression with fractional hour

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .stack-work/
 log/
 .idea/
+*.lock

--- a/Duckling/Duration/EN/Corpus.hs
+++ b/Duckling/Duration/EN/Corpus.hs
@@ -130,4 +130,10 @@ allExamples = concat
               ]
   , examples (DurationData 3630 Second)
               [ "an hour and 30 seconds"]
+  , examples (DurationData 930 Second)
+              [ "15.5 minutes"
+              , "15.5 minute"
+              , "15.5 mins"
+              , "15.5 min"
+              ]
   ]

--- a/Duckling/Duration/EN/Corpus.hs
+++ b/Duckling/Duration/EN/Corpus.hs
@@ -120,4 +120,14 @@ allExamples = concat
              , "five and half min"
              , "5 and an half minute"
              ]
+  , examples (DurationData 105 Minute)
+              [ "an hour and 45 minutes"
+              , "one hour and 45 minutes"
+              ]
+  , examples (DurationData 90 Second)
+              [ "a minute and 30 seconds"
+              , "one minute and 30 seconds"
+              ]
+  , examples (DurationData 3630 Second)
+              [ "an hour and 30 seconds"]
   ]

--- a/Duckling/Duration/EN/Corpus.hs
+++ b/Duckling/Duration/EN/Corpus.hs
@@ -120,14 +120,4 @@ allExamples = concat
              , "five and half min"
              , "5 and an half minute"
              ]
-  , examples (DurationData 105 Minute)
-              [ "an hour and 45 minutes"
-              , "one hour and 45 minutes"
-              ]
-  , examples (DurationData 90 Second)
-              [ "a minute and 30 seconds"
-              , "one minute and 30 seconds"
-              ]
-  , examples (DurationData 3630 Second)
-              [ "an hour and 30 seconds"]
   ]

--- a/Duckling/Duration/EN/Corpus.hs
+++ b/Duckling/Duration/EN/Corpus.hs
@@ -87,10 +87,20 @@ allExamples = concat
              , "1 hour and thirty"
              , "1.5 hours"
              , "1.5 hrs"
+             , "one and two quarter hour"
+             , "one and two quarters hour"
+             , "one and two quarter of hour"
+             , "one and two quarters of hour"
              ]
   , examples (DurationData 75 Minute)
              [ "1 hour fifteen"
              , "1 hour and fifteen"
+             , "one and quarter hour"
+             , "one and a quarter hour"
+             , "one and one quarter hour"
+             , "one and quarter of hour"
+             , "one and a quarter of hour"
+             , "one and one quarter of hour"
              ]
   , examples (DurationData 130 Minute)
              [ "2 hours ten"
@@ -123,6 +133,12 @@ allExamples = concat
   , examples (DurationData 105 Minute)
               [ "an hour and 45 minutes"
               , "one hour and 45 minutes"
+              , "one and three quarter hour"
+              , "one and three quarters hour"
+              , "one and three quarter of hour"
+              , "one and three quarters of hour"
+              , "one and three quarter of hours"
+              , "one and three quarters of hours"
               ]
   , examples (DurationData 90 Second)
               [ "a minute and 30 seconds"
@@ -136,4 +152,10 @@ allExamples = concat
               , "15.5 mins"
               , "15.5 min"
               ]
+  , examples (DurationData 135 Minute)
+             [ "two and quarter hour"
+             , "two and a quarter of hour"
+             , "two and quarter of hours"
+             , "two and a quarter of hours"
+             ]
   ]

--- a/Duckling/Duration/EN/Rules.hs
+++ b/Duckling/Duration/EN/Rules.hs
@@ -240,9 +240,26 @@ ruleCompositeDuration = Rule
       _ -> Nothing
   }
 
+ruleCompositeDurationAnd :: Rule
+ruleCompositeDurationAnd = Rule
+  { name = "composite <duration> and <duration>"
+  , pattern =
+    [ dimension Duration
+    , regex ",|and"
+    , dimension Duration
+    ]
+  , prod = \case
+      (Token Duration DurationData{TDuration.value = v, TDuration.grain = g}:
+       _:
+       Token Duration dd@DurationData{TDuration.grain = dg}:
+       _) | g > dg -> Just . Token Duration $ duration g (v) <> dd
+      _ -> Nothing
+  }
+
 rules :: [Rule]
 rules =
-  [ ruleDurationQuarterOfAnHour
+  [ ruleCompositeDurationCommasAnd
+  , ruleDurationQuarterOfAnHour
   , ruleDurationHalfAnHourAbbrev
   , ruleDurationThreeQuartersOfAnHour
   , ruleDurationFortnight
@@ -257,5 +274,5 @@ rules =
   , ruleDurationPrecision
   , ruleNumeralQuotes
   , ruleCompositeDuration
-  , ruleCompositeDurationCommasAnd
+  , ruleCompositeDurationAnd
   ]

--- a/Duckling/Duration/EN/Rules.hs
+++ b/Duckling/Duration/EN/Rules.hs
@@ -240,26 +240,9 @@ ruleCompositeDuration = Rule
       _ -> Nothing
   }
 
-ruleCompositeDurationAnd :: Rule
-ruleCompositeDurationAnd = Rule
-  { name = "composite <duration> and <duration>"
-  , pattern =
-    [ dimension Duration
-    , regex ",|and"
-    , dimension Duration
-    ]
-  , prod = \case
-      (Token Duration DurationData{TDuration.value = v, TDuration.grain = g}:
-       _:
-       Token Duration dd@DurationData{TDuration.grain = dg}:
-       _) | g > dg -> Just . Token Duration $ duration g (v) <> dd
-      _ -> Nothing
-  }
-
 rules :: [Rule]
 rules =
-  [ ruleCompositeDurationCommasAnd
-  , ruleDurationQuarterOfAnHour
+  [ ruleDurationQuarterOfAnHour
   , ruleDurationHalfAnHourAbbrev
   , ruleDurationThreeQuartersOfAnHour
   , ruleDurationFortnight
@@ -274,5 +257,5 @@ rules =
   , ruleDurationPrecision
   , ruleNumeralQuotes
   , ruleCompositeDuration
-  , ruleCompositeDurationAnd
+  , ruleCompositeDurationCommasAnd
   ]

--- a/Duckling/Duration/EN/Rules.hs
+++ b/Duckling/Duration/EN/Rules.hs
@@ -256,6 +256,22 @@ ruleCompositeDurationAnd = Rule
       _ -> Nothing
   }
 
+ruleDurationDotNumeralMinutes :: Rule
+ruleDurationDotNumeralMinutes = Rule
+  { name = "number.number minutes"
+  , pattern =
+    [ regex "(\\d+)\\.(\\d+)"
+    , Predicate $ isGrain TG.Minute
+    ]
+  , prod = \case
+      (Token RegexMatch (GroupMatch (m:s:_)):_) -> do
+        mm <- parseInteger m
+        ss <- parseInteger s
+        let sden = 10 ^ Text.length s
+        Just . Token Duration $ secondsFromHourMixedFraction mm ss sden
+      _ -> Nothing
+  }
+
 rules :: [Rule]
 rules =
   [ ruleCompositeDurationCommasAnd
@@ -275,4 +291,5 @@ rules =
   , ruleNumeralQuotes
   , ruleCompositeDuration
   , ruleCompositeDurationAnd
+  , ruleDurationDotNumeralMinutes
   ]

--- a/Duckling/Duration/Helpers.hs
+++ b/Duckling/Duration/Helpers.hs
@@ -13,6 +13,7 @@ module Duckling.Duration.Helpers
   , isNatural
   , minutesFromHourMixedFraction
   , nPlusOneHalf
+  , secondsFromHourMixedFraction
   ) where
 
 import Prelude
@@ -49,3 +50,7 @@ nPlusOneHalf grain = case grain of
   TG.Month  -> Just . duration TG.Day    . (15+) . (30*)
   TG.Year   -> Just . duration TG.Month  . (6+)  . (12*)
   _         -> const Nothing
+
+secondsFromHourMixedFraction :: Integer -> Integer -> Integer -> DurationData
+secondsFromHourMixedFraction m s d =
+  duration TG.Second $ fromIntegral $ 60 * m + quot (s * 60) d

--- a/Duckling/Ranking/Classifiers/ES_AR.hs
+++ b/Duckling/Ranking/Classifiers/ES_AR.hs
@@ -347,22 +347,15 @@ classifiers
                                n = 2}}),
        ("<time-of-day> horas",
         Classifier{okData =
-                     ClassData{prior = -1.0986122886681098,
-                               unseen = -2.0794415416798357,
+                     ClassData{prior = 0.0, unseen = -1.6094379124341003,
                                likelihoods =
                                  HashMap.fromList
-                                   [("a las <time-of-day>", -1.252762968495368),
-                                    ("time-of-day (latent)", -1.252762968495368),
-                                    ("hour", -0.8472978603872037)],
-                               n = 2},
+                                   [("time-of-day (latent)", -0.6931471805599453),
+                                    ("hour", -0.6931471805599453)],
+                               n = 1},
                    koData =
-                     ClassData{prior = -0.40546510810816444,
-                               unseen = -2.4849066497880004,
-                               likelihoods =
-                                 HashMap.fromList
-                                   [("time-of-day (latent)", -0.7884573603642702),
-                                    ("hour", -0.7884573603642702)],
-                               n = 4}}),
+                     ClassData{prior = -infinity, unseen = -1.0986122886681098,
+                               likelihoods = HashMap.fromList [], n = 0}}),
        ("intersect",
         Classifier{okData =
                      ClassData{prior = -0.2113090936672069, unseen = -4.634728988229636,
@@ -765,7 +758,7 @@ classifiers
                                likelihoods = HashMap.fromList [("", 0.0)], n = 2}}),
        ("time-of-day (latent)",
         Classifier{okData =
-                     ClassData{prior = -0.2478361639045812,
+                     ClassData{prior = -0.14518200984449783,
                                unseen = -3.5553480614894135,
                                likelihoods =
                                  HashMap.fromList
@@ -773,13 +766,12 @@ classifiers
                                     ("number (0..15)", -0.3483066942682157)],
                                n = 32},
                    koData =
-                     ClassData{prior = -1.5163474893680884,
-                               unseen = -2.4849066497880004,
+                     ClassData{prior = -2.001480000210124, unseen = -2.0794415416798357,
                                likelihoods =
                                  HashMap.fromList
-                                   [("integer (numeric)", -0.7884573603642702),
-                                    ("number (0..15)", -0.6061358035703156)],
-                               n = 9}}),
+                                   [("integer (numeric)", -0.5596157879354228),
+                                    ("number (0..15)", -0.8472978603872037)],
+                               n = 5}}),
        ("<hour-of-day> and <relative minutes>",
         Classifier{okData =
                      ClassData{prior = -0.3364722366212129, unseen = -3.332204510175204,

--- a/Duckling/Ranking/Classifiers/ES_CL.hs
+++ b/Duckling/Ranking/Classifiers/ES_CL.hs
@@ -347,22 +347,15 @@ classifiers
                                n = 2}}),
        ("<time-of-day> horas",
         Classifier{okData =
-                     ClassData{prior = -1.0986122886681098,
-                               unseen = -2.0794415416798357,
+                     ClassData{prior = 0.0, unseen = -1.6094379124341003,
                                likelihoods =
                                  HashMap.fromList
-                                   [("a las <time-of-day>", -1.252762968495368),
-                                    ("time-of-day (latent)", -1.252762968495368),
-                                    ("hour", -0.8472978603872037)],
-                               n = 2},
+                                   [("time-of-day (latent)", -0.6931471805599453),
+                                    ("hour", -0.6931471805599453)],
+                               n = 1},
                    koData =
-                     ClassData{prior = -0.40546510810816444,
-                               unseen = -2.4849066497880004,
-                               likelihoods =
-                                 HashMap.fromList
-                                   [("time-of-day (latent)", -0.7884573603642702),
-                                    ("hour", -0.7884573603642702)],
-                               n = 4}}),
+                     ClassData{prior = -infinity, unseen = -1.0986122886681098,
+                               likelihoods = HashMap.fromList [], n = 0}}),
        ("intersect",
         Classifier{okData =
                      ClassData{prior = -0.2113090936672069, unseen = -4.634728988229636,
@@ -765,7 +758,7 @@ classifiers
                                likelihoods = HashMap.fromList [("", 0.0)], n = 2}}),
        ("time-of-day (latent)",
         Classifier{okData =
-                     ClassData{prior = -0.2478361639045812,
+                     ClassData{prior = -0.14518200984449783,
                                unseen = -3.5553480614894135,
                                likelihoods =
                                  HashMap.fromList
@@ -773,13 +766,12 @@ classifiers
                                     ("number (0..15)", -0.3483066942682157)],
                                n = 32},
                    koData =
-                     ClassData{prior = -1.5163474893680884,
-                               unseen = -2.4849066497880004,
+                     ClassData{prior = -2.001480000210124, unseen = -2.0794415416798357,
                                likelihoods =
                                  HashMap.fromList
-                                   [("integer (numeric)", -0.7884573603642702),
-                                    ("number (0..15)", -0.6061358035703156)],
-                               n = 9}}),
+                                   [("integer (numeric)", -0.5596157879354228),
+                                    ("number (0..15)", -0.8472978603872037)],
+                               n = 5}}),
        ("<hour-of-day> and <relative minutes>",
         Classifier{okData =
                      ClassData{prior = -0.3364722366212129, unseen = -3.332204510175204,

--- a/Duckling/Ranking/Classifiers/ES_CO.hs
+++ b/Duckling/Ranking/Classifiers/ES_CO.hs
@@ -347,22 +347,15 @@ classifiers
                                n = 2}}),
        ("<time-of-day> horas",
         Classifier{okData =
-                     ClassData{prior = -1.0986122886681098,
-                               unseen = -2.0794415416798357,
+                     ClassData{prior = 0.0, unseen = -1.6094379124341003,
                                likelihoods =
                                  HashMap.fromList
-                                   [("a las <time-of-day>", -1.252762968495368),
-                                    ("time-of-day (latent)", -1.252762968495368),
-                                    ("hour", -0.8472978603872037)],
-                               n = 2},
+                                   [("time-of-day (latent)", -0.6931471805599453),
+                                    ("hour", -0.6931471805599453)],
+                               n = 1},
                    koData =
-                     ClassData{prior = -0.40546510810816444,
-                               unseen = -2.4849066497880004,
-                               likelihoods =
-                                 HashMap.fromList
-                                   [("time-of-day (latent)", -0.7884573603642702),
-                                    ("hour", -0.7884573603642702)],
-                               n = 4}}),
+                     ClassData{prior = -infinity, unseen = -1.0986122886681098,
+                               likelihoods = HashMap.fromList [], n = 0}}),
        ("intersect",
         Classifier{okData =
                      ClassData{prior = -0.2113090936672069, unseen = -4.634728988229636,
@@ -765,7 +758,7 @@ classifiers
                                likelihoods = HashMap.fromList [("", 0.0)], n = 2}}),
        ("time-of-day (latent)",
         Classifier{okData =
-                     ClassData{prior = -0.2478361639045812,
+                     ClassData{prior = -0.14518200984449783,
                                unseen = -3.5553480614894135,
                                likelihoods =
                                  HashMap.fromList
@@ -773,13 +766,12 @@ classifiers
                                     ("number (0..15)", -0.3483066942682157)],
                                n = 32},
                    koData =
-                     ClassData{prior = -1.5163474893680884,
-                               unseen = -2.4849066497880004,
+                     ClassData{prior = -2.001480000210124, unseen = -2.0794415416798357,
                                likelihoods =
                                  HashMap.fromList
-                                   [("integer (numeric)", -0.7884573603642702),
-                                    ("number (0..15)", -0.6061358035703156)],
-                               n = 9}}),
+                                   [("integer (numeric)", -0.5596157879354228),
+                                    ("number (0..15)", -0.8472978603872037)],
+                               n = 5}}),
        ("<hour-of-day> and <relative minutes>",
         Classifier{okData =
                      ClassData{prior = -0.3364722366212129, unseen = -3.332204510175204,

--- a/Duckling/Ranking/Classifiers/ES_ES.hs
+++ b/Duckling/Ranking/Classifiers/ES_ES.hs
@@ -347,22 +347,15 @@ classifiers
                                n = 2}}),
        ("<time-of-day> horas",
         Classifier{okData =
-                     ClassData{prior = -1.0986122886681098,
-                               unseen = -2.0794415416798357,
+                     ClassData{prior = 0.0, unseen = -1.6094379124341003,
                                likelihoods =
                                  HashMap.fromList
-                                   [("a las <time-of-day>", -1.252762968495368),
-                                    ("time-of-day (latent)", -1.252762968495368),
-                                    ("hour", -0.8472978603872037)],
-                               n = 2},
+                                   [("time-of-day (latent)", -0.6931471805599453),
+                                    ("hour", -0.6931471805599453)],
+                               n = 1},
                    koData =
-                     ClassData{prior = -0.40546510810816444,
-                               unseen = -2.4849066497880004,
-                               likelihoods =
-                                 HashMap.fromList
-                                   [("time-of-day (latent)", -0.7884573603642702),
-                                    ("hour", -0.7884573603642702)],
-                               n = 4}}),
+                     ClassData{prior = -infinity, unseen = -1.0986122886681098,
+                               likelihoods = HashMap.fromList [], n = 0}}),
        ("intersect",
         Classifier{okData =
                      ClassData{prior = -0.2113090936672069, unseen = -4.634728988229636,
@@ -765,7 +758,7 @@ classifiers
                                likelihoods = HashMap.fromList [("", 0.0)], n = 2}}),
        ("time-of-day (latent)",
         Classifier{okData =
-                     ClassData{prior = -0.2478361639045812,
+                     ClassData{prior = -0.14518200984449783,
                                unseen = -3.5553480614894135,
                                likelihoods =
                                  HashMap.fromList
@@ -773,13 +766,12 @@ classifiers
                                     ("number (0..15)", -0.3483066942682157)],
                                n = 32},
                    koData =
-                     ClassData{prior = -1.5163474893680884,
-                               unseen = -2.4849066497880004,
+                     ClassData{prior = -2.001480000210124, unseen = -2.0794415416798357,
                                likelihoods =
                                  HashMap.fromList
-                                   [("integer (numeric)", -0.7884573603642702),
-                                    ("number (0..15)", -0.6061358035703156)],
-                               n = 9}}),
+                                   [("integer (numeric)", -0.5596157879354228),
+                                    ("number (0..15)", -0.8472978603872037)],
+                               n = 5}}),
        ("<hour-of-day> and <relative minutes>",
         Classifier{okData =
                      ClassData{prior = -0.3364722366212129, unseen = -3.332204510175204,

--- a/Duckling/Ranking/Classifiers/ES_MX.hs
+++ b/Duckling/Ranking/Classifiers/ES_MX.hs
@@ -347,22 +347,15 @@ classifiers
                                n = 2}}),
        ("<time-of-day> horas",
         Classifier{okData =
-                     ClassData{prior = -1.0986122886681098,
-                               unseen = -2.0794415416798357,
+                     ClassData{prior = 0.0, unseen = -1.6094379124341003,
                                likelihoods =
                                  HashMap.fromList
-                                   [("a las <time-of-day>", -1.252762968495368),
-                                    ("time-of-day (latent)", -1.252762968495368),
-                                    ("hour", -0.8472978603872037)],
-                               n = 2},
+                                   [("time-of-day (latent)", -0.6931471805599453),
+                                    ("hour", -0.6931471805599453)],
+                               n = 1},
                    koData =
-                     ClassData{prior = -0.40546510810816444,
-                               unseen = -2.4849066497880004,
-                               likelihoods =
-                                 HashMap.fromList
-                                   [("time-of-day (latent)", -0.7884573603642702),
-                                    ("hour", -0.7884573603642702)],
-                               n = 4}}),
+                     ClassData{prior = -infinity, unseen = -1.0986122886681098,
+                               likelihoods = HashMap.fromList [], n = 0}}),
        ("intersect",
         Classifier{okData =
                      ClassData{prior = -0.2113090936672069, unseen = -4.634728988229636,
@@ -765,7 +758,7 @@ classifiers
                                likelihoods = HashMap.fromList [("", 0.0)], n = 2}}),
        ("time-of-day (latent)",
         Classifier{okData =
-                     ClassData{prior = -0.2478361639045812,
+                     ClassData{prior = -0.14518200984449783,
                                unseen = -3.5553480614894135,
                                likelihoods =
                                  HashMap.fromList
@@ -773,13 +766,12 @@ classifiers
                                     ("number (0..15)", -0.3483066942682157)],
                                n = 32},
                    koData =
-                     ClassData{prior = -1.5163474893680884,
-                               unseen = -2.4849066497880004,
+                     ClassData{prior = -2.001480000210124, unseen = -2.0794415416798357,
                                likelihoods =
                                  HashMap.fromList
-                                   [("integer (numeric)", -0.7884573603642702),
-                                    ("number (0..15)", -0.6061358035703156)],
-                               n = 9}}),
+                                   [("integer (numeric)", -0.5596157879354228),
+                                    ("number (0..15)", -0.8472978603872037)],
+                               n = 5}}),
        ("<hour-of-day> and <relative minutes>",
         Classifier{okData =
                      ClassData{prior = -0.3364722366212129, unseen = -3.332204510175204,

--- a/Duckling/Ranking/Classifiers/ES_PE.hs
+++ b/Duckling/Ranking/Classifiers/ES_PE.hs
@@ -347,22 +347,15 @@ classifiers
                                n = 2}}),
        ("<time-of-day> horas",
         Classifier{okData =
-                     ClassData{prior = -1.0986122886681098,
-                               unseen = -2.0794415416798357,
+                     ClassData{prior = 0.0, unseen = -1.6094379124341003,
                                likelihoods =
                                  HashMap.fromList
-                                   [("a las <time-of-day>", -1.252762968495368),
-                                    ("time-of-day (latent)", -1.252762968495368),
-                                    ("hour", -0.8472978603872037)],
-                               n = 2},
+                                   [("time-of-day (latent)", -0.6931471805599453),
+                                    ("hour", -0.6931471805599453)],
+                               n = 1},
                    koData =
-                     ClassData{prior = -0.40546510810816444,
-                               unseen = -2.4849066497880004,
-                               likelihoods =
-                                 HashMap.fromList
-                                   [("time-of-day (latent)", -0.7884573603642702),
-                                    ("hour", -0.7884573603642702)],
-                               n = 4}}),
+                     ClassData{prior = -infinity, unseen = -1.0986122886681098,
+                               likelihoods = HashMap.fromList [], n = 0}}),
        ("intersect",
         Classifier{okData =
                      ClassData{prior = -0.2113090936672069, unseen = -4.634728988229636,
@@ -765,7 +758,7 @@ classifiers
                                likelihoods = HashMap.fromList [("", 0.0)], n = 2}}),
        ("time-of-day (latent)",
         Classifier{okData =
-                     ClassData{prior = -0.2478361639045812,
+                     ClassData{prior = -0.14518200984449783,
                                unseen = -3.5553480614894135,
                                likelihoods =
                                  HashMap.fromList
@@ -773,13 +766,12 @@ classifiers
                                     ("number (0..15)", -0.3483066942682157)],
                                n = 32},
                    koData =
-                     ClassData{prior = -1.5163474893680884,
-                               unseen = -2.4849066497880004,
+                     ClassData{prior = -2.001480000210124, unseen = -2.0794415416798357,
                                likelihoods =
                                  HashMap.fromList
-                                   [("integer (numeric)", -0.7884573603642702),
-                                    ("number (0..15)", -0.6061358035703156)],
-                               n = 9}}),
+                                   [("integer (numeric)", -0.5596157879354228),
+                                    ("number (0..15)", -0.8472978603872037)],
+                               n = 5}}),
        ("<hour-of-day> and <relative minutes>",
         Classifier{okData =
                      ClassData{prior = -0.3364722366212129, unseen = -3.332204510175204,

--- a/Duckling/Ranking/Classifiers/ES_VE.hs
+++ b/Duckling/Ranking/Classifiers/ES_VE.hs
@@ -347,22 +347,15 @@ classifiers
                                n = 2}}),
        ("<time-of-day> horas",
         Classifier{okData =
-                     ClassData{prior = -1.0986122886681098,
-                               unseen = -2.0794415416798357,
+                     ClassData{prior = 0.0, unseen = -1.6094379124341003,
                                likelihoods =
                                  HashMap.fromList
-                                   [("a las <time-of-day>", -1.252762968495368),
-                                    ("time-of-day (latent)", -1.252762968495368),
-                                    ("hour", -0.8472978603872037)],
-                               n = 2},
+                                   [("time-of-day (latent)", -0.6931471805599453),
+                                    ("hour", -0.6931471805599453)],
+                               n = 1},
                    koData =
-                     ClassData{prior = -0.40546510810816444,
-                               unseen = -2.4849066497880004,
-                               likelihoods =
-                                 HashMap.fromList
-                                   [("time-of-day (latent)", -0.7884573603642702),
-                                    ("hour", -0.7884573603642702)],
-                               n = 4}}),
+                     ClassData{prior = -infinity, unseen = -1.0986122886681098,
+                               likelihoods = HashMap.fromList [], n = 0}}),
        ("intersect",
         Classifier{okData =
                      ClassData{prior = -0.2113090936672069, unseen = -4.634728988229636,
@@ -765,7 +758,7 @@ classifiers
                                likelihoods = HashMap.fromList [("", 0.0)], n = 2}}),
        ("time-of-day (latent)",
         Classifier{okData =
-                     ClassData{prior = -0.2478361639045812,
+                     ClassData{prior = -0.14518200984449783,
                                unseen = -3.5553480614894135,
                                likelihoods =
                                  HashMap.fromList
@@ -773,13 +766,12 @@ classifiers
                                     ("number (0..15)", -0.3483066942682157)],
                                n = 32},
                    koData =
-                     ClassData{prior = -1.5163474893680884,
-                               unseen = -2.4849066497880004,
+                     ClassData{prior = -2.001480000210124, unseen = -2.0794415416798357,
                                likelihoods =
                                  HashMap.fromList
-                                   [("integer (numeric)", -0.7884573603642702),
-                                    ("number (0..15)", -0.6061358035703156)],
-                               n = 9}}),
+                                   [("integer (numeric)", -0.5596157879354228),
+                                    ("number (0..15)", -0.8472978603872037)],
+                               n = 5}}),
        ("<hour-of-day> and <relative minutes>",
         Classifier{okData =
                      ClassData{prior = -0.3364722366212129, unseen = -3.332204510175204,

--- a/Duckling/Ranking/Classifiers/ES_XX.hs
+++ b/Duckling/Ranking/Classifiers/ES_XX.hs
@@ -347,22 +347,15 @@ classifiers
                                n = 2}}),
        ("<time-of-day> horas",
         Classifier{okData =
-                     ClassData{prior = -1.0986122886681098,
-                               unseen = -2.0794415416798357,
+                     ClassData{prior = 0.0, unseen = -1.6094379124341003,
                                likelihoods =
                                  HashMap.fromList
-                                   [("a las <time-of-day>", -1.252762968495368),
-                                    ("time-of-day (latent)", -1.252762968495368),
-                                    ("hour", -0.8472978603872037)],
-                               n = 2},
+                                   [("time-of-day (latent)", -0.6931471805599453),
+                                    ("hour", -0.6931471805599453)],
+                               n = 1},
                    koData =
-                     ClassData{prior = -0.40546510810816444,
-                               unseen = -2.4849066497880004,
-                               likelihoods =
-                                 HashMap.fromList
-                                   [("time-of-day (latent)", -0.7884573603642702),
-                                    ("hour", -0.7884573603642702)],
-                               n = 4}}),
+                     ClassData{prior = -infinity, unseen = -1.0986122886681098,
+                               likelihoods = HashMap.fromList [], n = 0}}),
        ("intersect",
         Classifier{okData =
                      ClassData{prior = -0.2113090936672069, unseen = -4.634728988229636,
@@ -765,7 +758,7 @@ classifiers
                                likelihoods = HashMap.fromList [("", 0.0)], n = 2}}),
        ("time-of-day (latent)",
         Classifier{okData =
-                     ClassData{prior = -0.2478361639045812,
+                     ClassData{prior = -0.14518200984449783,
                                unseen = -3.5553480614894135,
                                likelihoods =
                                  HashMap.fromList
@@ -773,13 +766,12 @@ classifiers
                                     ("number (0..15)", -0.3483066942682157)],
                                n = 32},
                    koData =
-                     ClassData{prior = -1.5163474893680884,
-                               unseen = -2.4849066497880004,
+                     ClassData{prior = -2.001480000210124, unseen = -2.0794415416798357,
                                likelihoods =
                                  HashMap.fromList
-                                   [("integer (numeric)", -0.7884573603642702),
-                                    ("number (0..15)", -0.6061358035703156)],
-                               n = 9}}),
+                                   [("integer (numeric)", -0.5596157879354228),
+                                    ("number (0..15)", -0.8472978603872037)],
+                               n = 5}}),
        ("<hour-of-day> and <relative minutes>",
         Classifier{okData =
                      ClassData{prior = -0.3364722366212129, unseen = -3.332204510175204,

--- a/Duckling/Time/ES/Corpus.hs
+++ b/Duckling/Time/ES/Corpus.hs
@@ -9,6 +9,7 @@
 
 module Duckling.Time.ES.Corpus
   ( corpus
+    , latentCorpus
   ) where
 
 import Data.String
@@ -19,9 +20,22 @@ import Duckling.Resolve
 import Duckling.Time.Corpus
 import Duckling.TimeGrain.Types hiding (add)
 import Duckling.Testing.Types hiding (examples)
+import Duckling.Time.Types hiding (Month)
+
+context :: Context
+context = testContext {locale = makeLocale ES Nothing}
+
+latentCorpus :: Corpus
+latentCorpus = (context, testOptions {withLatent = True}, xs)
+  where
+    xs = concat
+      [ examples (datetime (2013, 2, 12, 13, 0, 0) Hour)
+                 [ "una hora"
+                 ]
+      ]
 
 corpus :: Corpus
-corpus = (testContext {locale = makeLocale ES Nothing}, testOptions, allExamples)
+corpus = (context, testOptions, allExamples)
 
 allExamples :: [Example]
 allExamples = concat

--- a/Duckling/Time/ES/Rules.hs
+++ b/Duckling/Time/ES/Rules.hs
@@ -866,7 +866,7 @@ ruleTimeofdayHoras = Rule
     ]
   , prod = \tokens -> case tokens of
       (Token Time td:_) ->
-        tt $ notLatent td
+        tt $ mkLatent td
       _ -> Nothing
   }
 

--- a/tests/Duckling/Time/ES/Tests.hs
+++ b/tests/Duckling/Time/ES/Tests.hs
@@ -19,4 +19,5 @@ import Duckling.Time.ES.Corpus
 tests :: TestTree
 tests = testGroup "ES Tests"
   [ makeCorpusTest [This Time] corpus
+    , makeCorpusTest [This Time] latentCorpus
   ]

--- a/tests/TestMain.hs
+++ b/tests/TestMain.hs
@@ -4,7 +4,7 @@
 -- This source code is licensed under the BSD-style license found in the
 -- LICENSE file in the root directory of this source tree.
 
-module TestMain where
+-- module TestMain where
 
 import Data.String
 import Test.Tasty


### PR DESCRIPTION
Current:

if the fractional hour expression describes the hour fraction with term like "quarter or quarters", then duckling couldn't correctly recognize it.

Expected:

Duckling should be able to identify this kind of expression and parse it correctly.

Fix:

Add new rule to parse the fractional hour pattern that contains the keyword like "quarter or quarters".