### PR TITLE
Fixed problem with parsing fractional (with decimal) minutes

### DIFF
--- a/Duckling/Duration/EN/Corpus.hs
+++ b/Duckling/Duration/EN/Corpus.hs
@@ -120,4 +120,10 @@ allExamples = concat
              , "five and half min"
              , "5 and an half minute"
              ]
+  , examples (DurationData 930 Second)
+              [ "15.5 minutes"
+              , "15.5 minute"
+              , "15.5 mins"
+              , "15.5 min"
+              ]
   ]

--- a/Duckling/Duration/EN/Rules.hs
+++ b/Duckling/Duration/EN/Rules.hs
@@ -240,6 +240,22 @@ ruleCompositeDuration = Rule
       _ -> Nothing
   }
 
+ruleDurationDotNumeralMinutes :: Rule
+ruleDurationDotNumeralMinutes = Rule
+  { name = "number.number minutes"
+  , pattern =
+    [ regex "(\\d+)\\.(\\d+)"
+    , Predicate $ isGrain TG.Minute
+    ]
+  , prod = \case
+      (Token RegexMatch (GroupMatch (m:s:_)):_) -> do
+        mm <- parseInteger m
+        ss <- parseInteger s
+        let sden = 10 ^ Text.length s
+        Just . Token Duration $ secondsFromHourMixedFraction mm ss sden
+      _ -> Nothing
+  }
+
 rules :: [Rule]
 rules =
   [ ruleDurationQuarterOfAnHour
@@ -258,4 +274,5 @@ rules =
   , ruleNumeralQuotes
   , ruleCompositeDuration
   , ruleCompositeDurationCommasAnd
+  , ruleDurationDotNumeralMinutes
   ]

--- a/Duckling/Duration/Helpers.hs
+++ b/Duckling/Duration/Helpers.hs
@@ -13,6 +13,7 @@ module Duckling.Duration.Helpers
   , isNatural
   , minutesFromHourMixedFraction
   , nPlusOneHalf
+  , secondsFromHourMixedFraction
   ) where
 
 import Prelude
@@ -49,3 +50,7 @@ nPlusOneHalf grain = case grain of
   TG.Month  -> Just . duration TG.Day    . (15+) . (30*)
   TG.Year   -> Just . duration TG.Month  . (6+)  . (12*)
   _         -> const Nothing
+
+secondsFromHourMixedFraction :: Integer -> Integer -> Integer -> DurationData
+secondsFromHourMixedFraction m s d =
+  duration TG.Second $ fromIntegral $ 60 * m + quot (s * 60) d 


### PR DESCRIPTION
Current behavior
sentence with pattern "xxx.yyy minutes" parsed as yyy minutes.

Expected behavior:
xxx.yyy minutes = 60*xxx+0.yyy*60 seconds

For example:
"15.5" minutes = 60*15+0.560 = 930 seconds