### PR TITLE
Fixed the problem with parsing fractional hour phrase that contains "quarter" or "quarters"

### DIFF
--- a/Duckling/Duration/EN/Corpus.hs
+++ b/Duckling/Duration/EN/Corpus.hs
@@ -87,10 +87,20 @@ allExamples = concat
              , "1 hour and thirty"
              , "1.5 hours"
              , "1.5 hrs"
+             , "one and two quarter hour"
+             , "one and two quarters hour"
+             , "one and two quarter of hour"
+             , "one and two quarters of hour"
              ]
   , examples (DurationData 75 Minute)
              [ "1 hour fifteen"
              , "1 hour and fifteen"
+             , "one and quarter hour"
+             , "one and a quarter hour"
+             , "one and one quarter hour"
+             , "one and quarter of hour"
+             , "one and a quarter of hour"
+             , "one and one quarter of hour"
              ]
   , examples (DurationData 130 Minute)
              [ "2 hours ten"
@@ -119,5 +129,19 @@ allExamples = concat
              [ "5 and a half minutes"
              , "five and half min"
              , "5 and an half minute"
+             ]
+  , examples (DurationData 105 Minute)
+              [ "one and three quarter hour"
+              , "one and three quarters hour"
+              , "one and three quarter of hour"
+              , "one and three quarters of hour"
+              , "one and three quarter of hours"
+              , "one and three quarters of hours"
+              ]
+  , examples (DurationData 135 Minute)
+             [ "two and quarter hour"
+             , "two and a quarter of hour"
+             , "two and quarter of hours"
+             , "two and a quarter of hours"
              ]
   ]

--- a/Duckling/Duration/EN/Rules.hs
+++ b/Duckling/Duration/EN/Rules.hs
@@ -240,6 +240,28 @@ ruleCompositeDuration = Rule
       _ -> Nothing
   }
 
+ruleDurationNumeralAndQuarterHour :: Rule
+ruleDurationNumeralAndQuarterHour = Rule
+  { name = "<Integer> and <Integer> quarter of hour"
+  , pattern =
+    [ Predicate isNatural
+    , regex "and"
+    , regex "(a |an |one |two |three )?quarter(s)?(( of )?|( )+)hour(s)?"
+    ]
+  , prod = \case
+      (Token Numeral NumeralData{TNumeral.value = h}:
+       _:
+       Token RegexMatch (GroupMatch (match:_)):
+       _) -> do
+         q <- case Text.strip $ Text.toLower match of "a"     -> Just 1
+                                                      "an"    -> Just 1
+                                                      "one"   -> Just 1
+                                                      "two"   -> Just 2
+                                                      "three" -> Just 3
+                                                      _       -> Just 1
+         Just . Token Duration . duration TG.Minute $ 15 * q + 60 * floor h
+  }
+
 rules :: [Rule]
 rules =
   [ ruleDurationQuarterOfAnHour
@@ -258,4 +280,5 @@ rules =
   , ruleNumeralQuotes
   , ruleCompositeDuration
   , ruleCompositeDurationCommasAnd
+  , ruleDurationNumeralAndQuarterHour
   ]


### PR DESCRIPTION
Current:

if the fractional hour expression describes the hour fraction with term like "quarter or quarters", then duckling couldn't correctly recognize it.

Expected:

Duckling should be able to identify this kind of expression and parse it correctly.

Fix:

Add new rule to parse the fractional hour pattern that contains the keyword like "quarter or quarters".