### PR TITLE
Fixed a problem with parsing the phrase for day of month

### DIFF
--- a/Duckling/Duration/EN/Corpus.hs
+++ b/Duckling/Duration/EN/Corpus.hs
@@ -87,10 +87,20 @@ allExamples = concat
              , "1 hour and thirty"
              , "1.5 hours"
              , "1.5 hrs"
+             , "one and two quarter hour"
+             , "one and two quarters hour"
+             , "one and two quarter of hour"
+             , "one and two quarters of hour"
              ]
   , examples (DurationData 75 Minute)
              [ "1 hour fifteen"
              , "1 hour and fifteen"
+             , "one and quarter hour"
+             , "one and a quarter hour"
+             , "one and one quarter hour"
+             , "one and quarter of hour"
+             , "one and a quarter of hour"
+             , "one and one quarter of hour"
              ]
   , examples (DurationData 130 Minute)
              [ "2 hours ten"
@@ -119,5 +129,19 @@ allExamples = concat
              [ "5 and a half minutes"
              , "five and half min"
              , "5 and an half minute"
+             ]
+  , examples (DurationData 105 Minute)
+              [ "one and three quarter hour"
+              , "one and three quarters hour"
+              , "one and three quarter of hour"
+              , "one and three quarters of hour"
+              , "one and three quarter of hours"
+              , "one and three quarters of hours"
+              ]
+  , examples (DurationData 135 Minute)
+             [ "two and quarter hour"
+             , "two and a quarter of hour"
+             , "two and quarter of hours"
+             , "two and a quarter of hours"
              ]
   ]

--- a/Duckling/Duration/EN/Rules.hs
+++ b/Duckling/Duration/EN/Rules.hs
@@ -240,6 +240,28 @@ ruleCompositeDuration = Rule
       _ -> Nothing
   }
 
+ruleDurationNumeralAndQuarterHour :: Rule
+ruleDurationNumeralAndQuarterHour = Rule
+  { name = "<Integer> and <Integer> quarter of hour"
+  , pattern =
+    [ Predicate isNatural
+    , regex "and"
+    , regex "(a |an |one |two |three )?quarter(s)?(( of )?|( )+)hour(s)?"
+    ]
+  , prod = \case
+      (Token Numeral NumeralData{TNumeral.value = h}:
+       _:
+       Token RegexMatch (GroupMatch (match:_)):
+       _) -> do
+         q <- case Text.strip $ Text.toLower match of "a"     -> Just 1
+                                                      "an"    -> Just 1
+                                                      "one"   -> Just 1
+                                                      "two"   -> Just 2
+                                                      "three" -> Just 3
+                                                      _       -> Just 1
+         Just . Token Duration . duration TG.Minute $ 15 * q + 60 * floor h
+  }
+
 rules :: [Rule]
 rules =
   [ ruleDurationQuarterOfAnHour
@@ -258,4 +280,5 @@ rules =
   , ruleNumeralQuotes
   , ruleCompositeDuration
   , ruleCompositeDurationCommasAnd
+  , ruleDurationNumeralAndQuarterHour
   ]

--- a/Duckling/Ranking/Classifiers/ES_AR.hs
+++ b/Duckling/Ranking/Classifiers/ES_AR.hs
@@ -195,6 +195,13 @@ classifiers
                    koData =
                      ClassData{prior = -infinity, unseen = -2.5649493574615367,
                                likelihoods = HashMap.fromList [], n = 0}}),
+       ("el dia <day-of-month> (non ordinal)",
+        Classifier{okData =
+                     ClassData{prior = 0.0, unseen = -1.0986122886681098,
+                               likelihoods = HashMap.fromList [("number (0..15)", 0.0)], n = 1},
+                   koData =
+                     ClassData{prior = -infinity, unseen = -0.6931471805599453,
+                               likelihoods = HashMap.fromList [], n = 0}}),
        ("semana (grain)",
         Classifier{okData =
                      ClassData{prior = 0.0, unseen = -2.833213344056216,
@@ -640,11 +647,12 @@ classifiers
                                likelihoods = HashMap.fromList [], n = 0}}),
        ("number (0..15)",
         Classifier{okData =
-                     ClassData{prior = -3.922071315328127e-2,
-                               unseen = -3.951243718581427,
-                               likelihoods = HashMap.fromList [("", 0.0)], n = 50},
+                     ClassData{prior = -3.846628082779605e-2,
+                               unseen = -3.970291913552122,
+                               likelihoods = HashMap.fromList [("", 0.0)], n = 51},
                    koData =
-                     ClassData{prior = -3.258096538021482, unseen = -1.3862943611198906,
+                     ClassData{prior = -3.2771447329921766,
+                               unseen = -1.3862943611198906,
                                likelihoods = HashMap.fromList [("", 0.0)], n = 2}}),
        ("D\237a Internacional de las Cooperativas",
         Classifier{okData =

--- a/Duckling/Ranking/Classifiers/ES_CL.hs
+++ b/Duckling/Ranking/Classifiers/ES_CL.hs
@@ -195,6 +195,13 @@ classifiers
                    koData =
                      ClassData{prior = -infinity, unseen = -2.5649493574615367,
                                likelihoods = HashMap.fromList [], n = 0}}),
+       ("el dia <day-of-month> (non ordinal)",
+        Classifier{okData =
+                     ClassData{prior = 0.0, unseen = -1.0986122886681098,
+                               likelihoods = HashMap.fromList [("number (0..15)", 0.0)], n = 1},
+                   koData =
+                     ClassData{prior = -infinity, unseen = -0.6931471805599453,
+                               likelihoods = HashMap.fromList [], n = 0}}),
        ("semana (grain)",
         Classifier{okData =
                      ClassData{prior = 0.0, unseen = -2.833213344056216,
@@ -640,11 +647,12 @@ classifiers
                                likelihoods = HashMap.fromList [], n = 0}}),
        ("number (0..15)",
         Classifier{okData =
-                     ClassData{prior = -3.922071315328127e-2,
-                               unseen = -3.951243718581427,
-                               likelihoods = HashMap.fromList [("", 0.0)], n = 50},
+                     ClassData{prior = -3.846628082779605e-2,
+                               unseen = -3.970291913552122,
+                               likelihoods = HashMap.fromList [("", 0.0)], n = 51},
                    koData =
-                     ClassData{prior = -3.258096538021482, unseen = -1.3862943611198906,
+                     ClassData{prior = -3.2771447329921766,
+                               unseen = -1.3862943611198906,
                                likelihoods = HashMap.fromList [("", 0.0)], n = 2}}),
        ("D\237a Internacional de las Cooperativas",
         Classifier{okData =

--- a/Duckling/Ranking/Classifiers/ES_CO.hs
+++ b/Duckling/Ranking/Classifiers/ES_CO.hs
@@ -195,6 +195,13 @@ classifiers
                    koData =
                      ClassData{prior = -infinity, unseen = -2.5649493574615367,
                                likelihoods = HashMap.fromList [], n = 0}}),
+       ("el dia <day-of-month> (non ordinal)",
+        Classifier{okData =
+                     ClassData{prior = 0.0, unseen = -1.0986122886681098,
+                               likelihoods = HashMap.fromList [("number (0..15)", 0.0)], n = 1},
+                   koData =
+                     ClassData{prior = -infinity, unseen = -0.6931471805599453,
+                               likelihoods = HashMap.fromList [], n = 0}}),
        ("semana (grain)",
         Classifier{okData =
                      ClassData{prior = 0.0, unseen = -2.833213344056216,
@@ -640,11 +647,12 @@ classifiers
                                likelihoods = HashMap.fromList [], n = 0}}),
        ("number (0..15)",
         Classifier{okData =
-                     ClassData{prior = -3.922071315328127e-2,
-                               unseen = -3.951243718581427,
-                               likelihoods = HashMap.fromList [("", 0.0)], n = 50},
+                     ClassData{prior = -3.846628082779605e-2,
+                               unseen = -3.970291913552122,
+                               likelihoods = HashMap.fromList [("", 0.0)], n = 51},
                    koData =
-                     ClassData{prior = -3.258096538021482, unseen = -1.3862943611198906,
+                     ClassData{prior = -3.2771447329921766,
+                               unseen = -1.3862943611198906,
                                likelihoods = HashMap.fromList [("", 0.0)], n = 2}}),
        ("D\237a Internacional de las Cooperativas",
         Classifier{okData =

--- a/Duckling/Ranking/Classifiers/ES_ES.hs
+++ b/Duckling/Ranking/Classifiers/ES_ES.hs
@@ -195,6 +195,13 @@ classifiers
                    koData =
                      ClassData{prior = -infinity, unseen = -2.5649493574615367,
                                likelihoods = HashMap.fromList [], n = 0}}),
+       ("el dia <day-of-month> (non ordinal)",
+        Classifier{okData =
+                     ClassData{prior = 0.0, unseen = -1.0986122886681098,
+                               likelihoods = HashMap.fromList [("number (0..15)", 0.0)], n = 1},
+                   koData =
+                     ClassData{prior = -infinity, unseen = -0.6931471805599453,
+                               likelihoods = HashMap.fromList [], n = 0}}),
        ("semana (grain)",
         Classifier{okData =
                      ClassData{prior = 0.0, unseen = -2.833213344056216,
@@ -640,11 +647,12 @@ classifiers
                                likelihoods = HashMap.fromList [], n = 0}}),
        ("number (0..15)",
         Classifier{okData =
-                     ClassData{prior = -3.922071315328127e-2,
-                               unseen = -3.951243718581427,
-                               likelihoods = HashMap.fromList [("", 0.0)], n = 50},
+                     ClassData{prior = -3.846628082779605e-2,
+                               unseen = -3.970291913552122,
+                               likelihoods = HashMap.fromList [("", 0.0)], n = 51},
                    koData =
-                     ClassData{prior = -3.258096538021482, unseen = -1.3862943611198906,
+                     ClassData{prior = -3.2771447329921766,
+                               unseen = -1.3862943611198906,
                                likelihoods = HashMap.fromList [("", 0.0)], n = 2}}),
        ("D\237a Internacional de las Cooperativas",
         Classifier{okData =

--- a/Duckling/Ranking/Classifiers/ES_MX.hs
+++ b/Duckling/Ranking/Classifiers/ES_MX.hs
@@ -195,6 +195,13 @@ classifiers
                    koData =
                      ClassData{prior = -infinity, unseen = -2.5649493574615367,
                                likelihoods = HashMap.fromList [], n = 0}}),
+       ("el dia <day-of-month> (non ordinal)",
+        Classifier{okData =
+                     ClassData{prior = 0.0, unseen = -1.0986122886681098,
+                               likelihoods = HashMap.fromList [("number (0..15)", 0.0)], n = 1},
+                   koData =
+                     ClassData{prior = -infinity, unseen = -0.6931471805599453,
+                               likelihoods = HashMap.fromList [], n = 0}}),
        ("semana (grain)",
         Classifier{okData =
                      ClassData{prior = 0.0, unseen = -2.833213344056216,
@@ -640,11 +647,12 @@ classifiers
                                likelihoods = HashMap.fromList [], n = 0}}),
        ("number (0..15)",
         Classifier{okData =
-                     ClassData{prior = -3.922071315328127e-2,
-                               unseen = -3.951243718581427,
-                               likelihoods = HashMap.fromList [("", 0.0)], n = 50},
+                     ClassData{prior = -3.846628082779605e-2,
+                               unseen = -3.970291913552122,
+                               likelihoods = HashMap.fromList [("", 0.0)], n = 51},
                    koData =
-                     ClassData{prior = -3.258096538021482, unseen = -1.3862943611198906,
+                     ClassData{prior = -3.2771447329921766,
+                               unseen = -1.3862943611198906,
                                likelihoods = HashMap.fromList [("", 0.0)], n = 2}}),
        ("D\237a Internacional de las Cooperativas",
         Classifier{okData =

--- a/Duckling/Ranking/Classifiers/ES_PE.hs
+++ b/Duckling/Ranking/Classifiers/ES_PE.hs
@@ -195,6 +195,13 @@ classifiers
                    koData =
                      ClassData{prior = -infinity, unseen = -2.5649493574615367,
                                likelihoods = HashMap.fromList [], n = 0}}),
+       ("el dia <day-of-month> (non ordinal)",
+        Classifier{okData =
+                     ClassData{prior = 0.0, unseen = -1.0986122886681098,
+                               likelihoods = HashMap.fromList [("number (0..15)", 0.0)], n = 1},
+                   koData =
+                     ClassData{prior = -infinity, unseen = -0.6931471805599453,
+                               likelihoods = HashMap.fromList [], n = 0}}),
        ("semana (grain)",
         Classifier{okData =
                      ClassData{prior = 0.0, unseen = -2.833213344056216,
@@ -640,11 +647,12 @@ classifiers
                                likelihoods = HashMap.fromList [], n = 0}}),
        ("number (0..15)",
         Classifier{okData =
-                     ClassData{prior = -3.922071315328127e-2,
-                               unseen = -3.951243718581427,
-                               likelihoods = HashMap.fromList [("", 0.0)], n = 50},
+                     ClassData{prior = -3.846628082779605e-2,
+                               unseen = -3.970291913552122,
+                               likelihoods = HashMap.fromList [("", 0.0)], n = 51},
                    koData =
-                     ClassData{prior = -3.258096538021482, unseen = -1.3862943611198906,
+                     ClassData{prior = -3.2771447329921766,
+                               unseen = -1.3862943611198906,
                                likelihoods = HashMap.fromList [("", 0.0)], n = 2}}),
        ("D\237a Internacional de las Cooperativas",
         Classifier{okData =

--- a/Duckling/Ranking/Classifiers/ES_VE.hs
+++ b/Duckling/Ranking/Classifiers/ES_VE.hs
@@ -195,6 +195,13 @@ classifiers
                    koData =
                      ClassData{prior = -infinity, unseen = -2.5649493574615367,
                                likelihoods = HashMap.fromList [], n = 0}}),
+       ("el dia <day-of-month> (non ordinal)",
+        Classifier{okData =
+                     ClassData{prior = 0.0, unseen = -1.0986122886681098,
+                               likelihoods = HashMap.fromList [("number (0..15)", 0.0)], n = 1},
+                   koData =
+                     ClassData{prior = -infinity, unseen = -0.6931471805599453,
+                               likelihoods = HashMap.fromList [], n = 0}}),
        ("semana (grain)",
         Classifier{okData =
                      ClassData{prior = 0.0, unseen = -2.833213344056216,
@@ -640,11 +647,12 @@ classifiers
                                likelihoods = HashMap.fromList [], n = 0}}),
        ("number (0..15)",
         Classifier{okData =
-                     ClassData{prior = -3.922071315328127e-2,
-                               unseen = -3.951243718581427,
-                               likelihoods = HashMap.fromList [("", 0.0)], n = 50},
+                     ClassData{prior = -3.846628082779605e-2,
+                               unseen = -3.970291913552122,
+                               likelihoods = HashMap.fromList [("", 0.0)], n = 51},
                    koData =
-                     ClassData{prior = -3.258096538021482, unseen = -1.3862943611198906,
+                     ClassData{prior = -3.2771447329921766,
+                               unseen = -1.3862943611198906,
                                likelihoods = HashMap.fromList [("", 0.0)], n = 2}}),
        ("D\237a Internacional de las Cooperativas",
         Classifier{okData =

--- a/Duckling/Ranking/Classifiers/ES_XX.hs
+++ b/Duckling/Ranking/Classifiers/ES_XX.hs
@@ -195,6 +195,13 @@ classifiers
                    koData =
                      ClassData{prior = -infinity, unseen = -2.5649493574615367,
                                likelihoods = HashMap.fromList [], n = 0}}),
+       ("el dia <day-of-month> (non ordinal)",
+        Classifier{okData =
+                     ClassData{prior = 0.0, unseen = -1.0986122886681098,
+                               likelihoods = HashMap.fromList [("number (0..15)", 0.0)], n = 1},
+                   koData =
+                     ClassData{prior = -infinity, unseen = -0.6931471805599453,
+                               likelihoods = HashMap.fromList [], n = 0}}),
        ("semana (grain)",
         Classifier{okData =
                      ClassData{prior = 0.0, unseen = -2.833213344056216,
@@ -640,11 +647,12 @@ classifiers
                                likelihoods = HashMap.fromList [], n = 0}}),
        ("number (0..15)",
         Classifier{okData =
-                     ClassData{prior = -3.922071315328127e-2,
-                               unseen = -3.951243718581427,
-                               likelihoods = HashMap.fromList [("", 0.0)], n = 50},
+                     ClassData{prior = -3.846628082779605e-2,
+                               unseen = -3.970291913552122,
+                               likelihoods = HashMap.fromList [("", 0.0)], n = 51},
                    koData =
-                     ClassData{prior = -3.258096538021482, unseen = -1.3862943611198906,
+                     ClassData{prior = -3.2771447329921766,
+                               unseen = -1.3862943611198906,
                                likelihoods = HashMap.fromList [("", 0.0)], n = 2}}),
        ("D\237a Internacional de las Cooperativas",
         Classifier{okData =

--- a/Duckling/Time/ES/Corpus.hs
+++ b/Duckling/Time/ES/Corpus.hs
@@ -452,4 +452,7 @@ allExamples = concat
              , "día de las bromas de abril"
              , "día de las bromas"
              ]
+  , examples (datetime (2013, 3, 9, 0, 0, 0) Day)
+             [ "el día nueve"
+             ]
   ]

--- a/Duckling/Time/ES/Rules.hs
+++ b/Duckling/Time/ES/Rules.hs
@@ -1469,6 +1469,21 @@ rulePeriodicHolidays = mkRuleHolidays
     , predNthClosest 0 weekday (monthDay 10 16) )
   ]
 
+ruleElDayofmonthNonOrdinalWithDia :: Rule
+ruleElDayofmonthNonOrdinalWithDia = Rule
+  { name = "el dia <day-of-month> (non ordinal)"
+  , pattern =
+    [ regex "el"
+    , regex "día"
+    , Predicate $ isIntegerBetween 1 31
+    ]
+  , prod = \tokens -> case tokens of
+      (_:_:token:_) -> do
+        v <- getIntValue token
+        tt $ dayOfMonth v
+      _ -> Nothing
+  }
+
 rules :: [Rule]
 rules =
   [ ruleALasHourmintimeofday
@@ -1560,6 +1575,7 @@ rules =
   , ruleHourofdayMinusQuarter
   , ruleHourofdayMinusIntegerAsRelativeMinutes2
   , ruleTimezone
+  , ruleElDayofmonthNonOrdinalWithDia
   ]
   ++ ruleDaysOfWeek
   ++ ruleMonths


### PR DESCRIPTION
Current:

"el dia nueve" -> "9pm" of current day

Expected:
"el dia nueve" -> 9th of current or next month

Fix:

added new ES rule to handle the pattern like "el dia <some day
of current month>"