### PR TITLE
NL/Duration: Support composite durations

### DIFF
--- a/Duckling/Duration/NL/Corpus.hs
+++ b/Duckling/Duration/NL/Corpus.hs
@@ -57,6 +57,18 @@ allExamples = concat
   , examples (DurationData 45 Minute)
              [ "3 kwartier"
              ]
+  , examples (DurationData 75 Minute)
+             [ "een uur en een kwartier"
+             , "een uur en 15 minuten"
+             , "een uur, 15 minuten"
+             , "een uur 15 minuten"
+             ]
+  , examples (DurationData 165 Minute)
+             [ "twee uur en drie kwartier"
+             , "twee uur, 3 kwartier"
+             , "twee uur, 45 minuten"
+             , "twee uur 45 minuten"
+             ]
   , examples (DurationData 1 Hour)
              [ "een uur"
              , "één uur"
@@ -65,6 +77,7 @@ allExamples = concat
              ]
   , examples (DurationData 30 Day)
              [ "30 dagen"
+             , "4 weken en 2 dagen"
              ]
   , examples (DurationData 7 Day)
              [ "7 dagen"

--- a/Duckling/Duration/NL/Rules.hs
+++ b/Duckling/Duration/NL/Rules.hs
@@ -7,21 +7,25 @@
 
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE LambdaCase #-}
 
 module Duckling.Duration.NL.Rules
   ( rules ) where
 
 import Control.Monad (join)
 import Prelude
+import Data.Semigroup ((<>))
 import Data.String
 import qualified Data.Text as Text
 
 import Duckling.Dimensions.Types
 import Duckling.Duration.Helpers
+import Duckling.Duration.Types (DurationData(..))
 import Duckling.Numeral.Helpers (parseInt, parseInteger)
 import Duckling.Numeral.Types (NumeralData(..))
 import Duckling.Regex.Types
 import Duckling.Types
+import qualified Duckling.Duration.Types as TDuration
 import qualified Duckling.Numeral.Types as TNumeral
 import qualified Duckling.TimeGrain.Types as TG
 
@@ -102,6 +106,41 @@ ruleDurationAndHalfHour = Rule
       _ -> Nothing
   }
 
+-- | NOTE: Oxford comma is not supported.
+ruleCompositeDurationCommasAnd :: Rule
+ruleCompositeDurationCommasAnd = Rule
+  { name = "composite <duration> (with ,/and)"
+  , pattern =
+    [ Predicate isNatural
+    , dimension TimeGrain
+    , regex ",|en|plus"
+    , dimension Duration
+    ]
+  , prod = \case
+      (Token Numeral NumeralData{TNumeral.value = v}:
+       Token TimeGrain g:
+       _:
+       Token Duration dd@DurationData{TDuration.grain = dg}:
+       _) | g > dg -> Just . Token Duration $ duration g (floor v) <> dd
+      _ -> Nothing
+  }
+
+ruleCompositeDuration :: Rule
+ruleCompositeDuration = Rule
+  { name = "composite <duration>"
+  , pattern =
+    [ Predicate isNatural
+    , dimension TimeGrain
+    , dimension Duration
+    ]
+  , prod = \case
+      (Token Numeral NumeralData{TNumeral.value = v}:
+       Token TimeGrain g:
+       Token Duration dd@DurationData{TDuration.grain = dg}:
+       _) | g > dg -> Just . Token Duration $ duration g (floor v) <> dd
+      _ -> Nothing
+  }
+
 ruleDurationPrecision :: Rule
 ruleDurationPrecision = Rule
   { name = "about|exactly <duration>"
@@ -118,6 +157,8 @@ rules :: [Rule]
 rules =
   [ ruleDurationQuarterOfAnHour
   , ruleDurationKwartier
+  , ruleCompositeDurationCommasAnd
+  , ruleCompositeDuration
   , ruleDurationHalfAnHour
   , ruleDurationThreeQuartersOfAnHour
   , ruleDurationDotNumeralHours


### PR DESCRIPTION
E.g. "1 uur en drie kwartier", "1 dag 4 uur", etc.