### PR TITLE
NL/amount-of-money

### DIFF
--- a/Duckling/AmountOfMoney/NL/Corpus.hs
+++ b/Duckling/AmountOfMoney/NL/Corpus.hs
@@ -46,6 +46,8 @@ allExamples = concat
              [ "$10K"
              , "10k$"
              , "$10000"
+             , "$10.000"
+             , "$10.000,00"
              , "10000,00 $"
              ]
   , examples (simple USD 3.14)

--- a/Duckling/Numeral/NL/Corpus.hs
+++ b/Duckling/Numeral/NL/Corpus.hs
@@ -76,6 +76,14 @@ allExamples = concat
              [ "0,77"
              , ",77"
              ]
+  , examples (NumeralValue 100000)
+             [ "100.000"
+             , "100.000,0"
+             , "100000"
+             , "100K"
+             , "100k"
+             , "honderd duizend"
+             ]
   , examples (NumeralValue 300)
              [ "3 honderd"
              , "drie honderd"
@@ -83,6 +91,8 @@ allExamples = concat
   , examples (NumeralValue 5000)
              [ "5 duizend"
              , "vijf duizend"
+             , "5.000"
+             , "5.000,00"
              ]
   , examples (NumeralValue 144)
              [ "gros"
@@ -94,6 +104,9 @@ allExamples = concat
              ]
   , examples (NumeralValue 20000)
              [ "twintig duizend"
+             , "20.000"
+             , "20000"
+             , "20.000,00"
              ]
   , examples (NumeralValue 0.2)
              [ "1/5"

--- a/Duckling/Numeral/NL/Rules.hs
+++ b/Duckling/Numeral/NL/Rules.hs
@@ -62,7 +62,7 @@ ruleDecimalWithThousandsSeparator :: Rule
 ruleDecimalWithThousandsSeparator = Rule
   { name = "decimal with thousands separator"
   , pattern =
-    [ regex "(\\d+(\\.\\d\\d\\d)+,\\d+)"
+    [ regex "(\\d+(\\.\\d\\d\\d)+(,\\d+)?)"
     ]
   , prod = \tokens -> case tokens of
       (Token RegexMatch (GroupMatch (match:_)):


### PR DESCRIPTION
Currently values like 1000.000 (in Dutch . is thousand separator) are not recognised, as the ruleDecimalWithThousandsSeparator requires the decimal part (e.g. 1000.000,34) to be present. This PR adds some data and changes the ruleDecimalWithThousandsSeparator to make the decimal part optional.