### PR TITLE
Export default module name 'Main' from within TestMain.hs file

### DIFF
--- a/tests/TestMain.hs
+++ b/tests/TestMain.hs
@@ -4,7 +4,7 @@
 -- This source code is licensed under the BSD-style license found in the
 -- LICENSE file in the root directory of this source tree.
 
-module TestMain where
+module Main where
 
 import Data.String
 import Test.Tasty


### PR DESCRIPTION
**Summary**

**Current**
`stack test` fails with an error "output was redirected with -o, but no output will be generated
because there is no Main module"

**Expected**
`stack test` should run tests to completion

The cause here seems to be that the [`main-is` flag](https://github.com/facebook/duckling/blob/a88e0669f7d5889bda182b61bd05cdae697a2c07/duckling.cabal#L851) supplies the *filename* in which to begin tests, but expects to find a *module* named `Main` there by default.

Two possible fixes are possible - either:

- [Add a ghc-options flag](https://github.com/facebook/duckling/issues/505#issue-650474748) to specify a module name; confusingly the flag name is also `main-is`
- Use the default `Main` module name within TestMain.hs

(the approach taken here is the latter, since this avoids duplicating use of flags named `main-is` in slightly different contexts)

**References**
- https://github.com/facebook/duckling/issues/505
- https://github.com/haskell/cabal/issues/4315

**Version Info**
```sh
$ stack --version
1.9.3.1 x86_64
Compiled with:
- Cabal-2.4.0.1
# <remainder of output omitted>
```

Resolves #505 