### PR TITLE
Remove dependency on Data.Some

### DIFF
--- a/Duckling/Api.hs
+++ b/Duckling/Api.hs
@@ -35,22 +35,22 @@ import Duckling.Rules
 import Duckling.Types
 
 -- | Parses `input` and returns a curated list of entities found.
-parse :: Text -> Context -> Options -> [Some Dimension] -> [Entity]
+parse :: Text -> Context -> Options -> [Seal Dimension] -> [Entity]
 parse input ctx options = map (formatToken input) . analyze input ctx options .
   HashSet.fromList
 
-supportedDimensions :: HashMap Lang [Some Dimension]
+supportedDimensions :: HashMap Lang [Seal Dimension]
 supportedDimensions =
   HashMap.fromList [ (l, allDimensions l) | l <- [minBound..maxBound] ]
 
 -- | Returns a curated list of resolved tokens found
 -- When `targets` is non-empty, returns only tokens of such dimensions.
-analyze :: Text -> Context -> Options -> HashSet (Some Dimension)
+analyze :: Text -> Context -> Options -> HashSet (Seal Dimension)
   -> [ResolvedToken]
 analyze input context@Context{..} options targets =
   rank (classifiers locale) targets
   . filter (\Resolved{node = Node{token = (Token d _)}} ->
-      HashSet.null targets || HashSet.member (This d) targets
+      HashSet.null targets || HashSet.member (Seal d) targets
     )
   $ parseAndResolve (rulesFor locale targets) input context options
 

--- a/Duckling/Core.hs
+++ b/Duckling/Core.hs
@@ -20,7 +20,8 @@ module Duckling.Core
   , Range(..)
   , Region(..)
   , ResolvedVal(..)
-  , Some(..)
+  , Seal(..)
+  , withSeal
   , fromName
   , makeLocale
   , toJText

--- a/Duckling/Debug.hs
+++ b/Duckling/Debug.hs
@@ -36,20 +36,20 @@ import Duckling.Types
 -- -----------------------------------------------------------------
 -- API
 
-debug :: Locale -> Text -> [Some Dimension] -> IO [Entity]
+debug :: Locale -> Text -> [Seal Dimension] -> IO [Entity]
 debug locale = debugCustom testContext {locale = locale} testOptions
 
-allParses :: Locale -> Text -> [Some Dimension] -> IO [Entity]
+allParses :: Locale -> Text -> [Seal Dimension] -> IO [Entity]
 allParses l sentence targets = debugTokens sentence $ parses l sentence targets
 
-fullParses :: Locale -> Text -> [Some Dimension] -> IO [Entity]
+fullParses :: Locale -> Text -> [Seal Dimension] -> IO [Entity]
 fullParses l sentence targets = debugTokens sentence .
   filter (\Resolved{range = Range start end} -> start == 0 && end == n) $
   parses l sentence targets
   where
     n = Text.length sentence
 
-debugCustom :: Context -> Options -> Text -> [Some Dimension] -> IO [Entity]
+debugCustom :: Context -> Options -> Text -> [Seal Dimension] -> IO [Entity]
 debugCustom context options sentence targets = debugTokens sentence .
   analyze sentence context options $ HashSet.fromList targets
 
@@ -59,12 +59,12 @@ ptree sentence Entity {enode} = pnode sentence 0 enode
 -- -----------------------------------------------------------------
 -- Internals
 
-parses :: Locale -> Text -> [Some Dimension] -> [ResolvedToken]
+parses :: Locale -> Text -> [Seal Dimension] -> [ResolvedToken]
 parses l sentence targets = flip filter tokens $
   \Resolved{node = Node{token = (Token d _)}} ->
     case targets of
       [] -> True
-      _ -> elem (This d) targets
+      _ -> elem (Seal d) targets
   where
     tokens = parseAndResolve rules sentence testContext {locale = l} testOptions
     rules = rulesFor l $ HashSet.fromList targets

--- a/Duckling/Dimensions.hs
+++ b/Duckling/Dimensions.hs
@@ -69,36 +69,36 @@ import qualified Duckling.Dimensions.VI as VIDimensions
 import qualified Duckling.Dimensions.ZH as ZHDimensions
 
 
-allDimensions :: Lang -> [Some Dimension]
+allDimensions :: Lang -> [Seal Dimension]
 allDimensions lang = CommonDimensions.allDimensions ++ langDimensions lang
 
 -- | Augments `targets` with all dependent dimensions.
-explicitDimensions :: HashSet (Some Dimension) -> HashSet (Some Dimension)
+explicitDimensions :: HashSet (Seal Dimension) -> HashSet (Seal Dimension)
 explicitDimensions targets = HashSet.union targets deps
   where
     deps = HashSet.unions . map dependents $ HashSet.toList targets
 
 -- | Ordinal depends on Numeral for JA, KO, and ZH.
-dependents :: Some Dimension -> HashSet (Some Dimension)
-dependents (This CreditCardNumber) = HashSet.empty
-dependents (This Distance) = HashSet.singleton (This Numeral)
-dependents (This Duration) = HashSet.fromList [This Numeral, This TimeGrain]
-dependents (This Numeral) = HashSet.empty
-dependents (This Email) = HashSet.empty
-dependents (This AmountOfMoney) = HashSet.singleton (This Numeral)
-dependents (This Ordinal) = HashSet.singleton (This Numeral)
-dependents (This PhoneNumber) = HashSet.empty
-dependents (This Quantity) = HashSet.singleton (This Numeral)
-dependents (This RegexMatch) = HashSet.empty
-dependents (This Temperature) = HashSet.singleton (This Numeral)
-dependents (This Time) =
-  HashSet.fromList [This Numeral, This Duration, This Ordinal, This TimeGrain]
-dependents (This TimeGrain) = HashSet.empty
-dependents (This Url) = HashSet.empty
-dependents (This Volume) = HashSet.singleton (This Numeral)
-dependents (This (CustomDimension dim)) = dimDependents dim
+dependents :: Seal Dimension -> HashSet (Seal Dimension)
+dependents (Seal CreditCardNumber) = HashSet.empty
+dependents (Seal Distance) = HashSet.singleton (Seal Numeral)
+dependents (Seal Duration) = HashSet.fromList [Seal Numeral, Seal TimeGrain]
+dependents (Seal Numeral) = HashSet.empty
+dependents (Seal Email) = HashSet.empty
+dependents (Seal AmountOfMoney) = HashSet.singleton (Seal Numeral)
+dependents (Seal Ordinal) = HashSet.singleton (Seal Numeral)
+dependents (Seal PhoneNumber) = HashSet.empty
+dependents (Seal Quantity) = HashSet.singleton (Seal Numeral)
+dependents (Seal RegexMatch) = HashSet.empty
+dependents (Seal Temperature) = HashSet.singleton (Seal Numeral)
+dependents (Seal Time) =
+  HashSet.fromList [Seal Numeral, Seal Duration, Seal Ordinal, Seal TimeGrain]
+dependents (Seal TimeGrain) = HashSet.empty
+dependents (Seal Url) = HashSet.empty
+dependents (Seal Volume) = HashSet.singleton (Seal Numeral)
+dependents (Seal (CustomDimension dim)) = dimDependents dim
 
-langDimensions :: Lang -> [Some Dimension]
+langDimensions :: Lang -> [Seal Dimension]
 langDimensions AF = AFDimensions.allDimensions
 langDimensions AR = ARDimensions.allDimensions
 langDimensions BG = BGDimensions.allDimensions

--- a/Duckling/Dimensions/AF.hs
+++ b/Duckling/Dimensions/AF.hs
@@ -11,7 +11,7 @@ module Duckling.Dimensions.AF
 
 import Duckling.Dimensions.Types
 
-allDimensions :: [Some Dimension]
+allDimensions :: [Seal Dimension]
 allDimensions =
-  [ This Numeral
+  [ Seal Numeral
   ]

--- a/Duckling/Dimensions/AR.hs
+++ b/Duckling/Dimensions/AR.hs
@@ -11,13 +11,13 @@ module Duckling.Dimensions.AR
 
 import Duckling.Dimensions.Types
 
-allDimensions :: [Some Dimension]
+allDimensions :: [Seal Dimension]
 allDimensions =
-  [ This Duration
-  , This Numeral
-  , This Ordinal
-  , This Quantity
-  , This Temperature
-  , This Time
-  , This Volume
+  [ Seal Duration
+  , Seal Numeral
+  , Seal Ordinal
+  , Seal Quantity
+  , Seal Temperature
+  , Seal Time
+  , Seal Volume
   ]

--- a/Duckling/Dimensions/BG.hs
+++ b/Duckling/Dimensions/BG.hs
@@ -11,11 +11,11 @@ module Duckling.Dimensions.BG
 
 import Duckling.Dimensions.Types
 
-allDimensions :: [Some Dimension]
+allDimensions :: [Seal Dimension]
 allDimensions =
-  [ This Distance
-  , This Duration
-  , This Numeral
-  , This Ordinal
-  , This Time
+  [ Seal Distance
+  , Seal Duration
+  , Seal Numeral
+  , Seal Ordinal
+  , Seal Time
   ]

--- a/Duckling/Dimensions/BN.hs
+++ b/Duckling/Dimensions/BN.hs
@@ -11,7 +11,7 @@ module Duckling.Dimensions.BN
 
 import Duckling.Dimensions.Types
 
-allDimensions :: [Some Dimension]
+allDimensions :: [Seal Dimension]
 allDimensions =
-  [ This Numeral
+  [ Seal Numeral
   ]

--- a/Duckling/Dimensions/CS.hs
+++ b/Duckling/Dimensions/CS.hs
@@ -11,8 +11,8 @@ module Duckling.Dimensions.CS
 
 import Duckling.Dimensions.Types
 
-allDimensions :: [Some Dimension]
+allDimensions :: [Seal Dimension]
 allDimensions =
-  [ This Distance
-  , This Numeral
+  [ Seal Distance
+  , Seal Numeral
   ]

--- a/Duckling/Dimensions/Common.hs
+++ b/Duckling/Dimensions/Common.hs
@@ -11,11 +11,11 @@ module Duckling.Dimensions.Common
 
 import Duckling.Dimensions.Types
 
-allDimensions :: [Some Dimension]
+allDimensions :: [Seal Dimension]
 allDimensions =
-  [ This AmountOfMoney
-  , This Email
-  , This Numeral
-  , This PhoneNumber
-  , This Url
+  [ Seal AmountOfMoney
+  , Seal Email
+  , Seal Numeral
+  , Seal PhoneNumber
+  , Seal Url
   ]

--- a/Duckling/Dimensions/DA.hs
+++ b/Duckling/Dimensions/DA.hs
@@ -11,10 +11,10 @@ module Duckling.Dimensions.DA
 
 import Duckling.Dimensions.Types
 
-allDimensions :: [Some Dimension]
+allDimensions :: [Seal Dimension]
 allDimensions =
-  [ This Duration
-  , This Numeral
-  , This Ordinal
-  , This Time
+  [ Seal Duration
+  , Seal Numeral
+  , Seal Ordinal
+  , Seal Time
   ]

--- a/Duckling/Dimensions/DE.hs
+++ b/Duckling/Dimensions/DE.hs
@@ -11,12 +11,12 @@ module Duckling.Dimensions.DE
 
 import Duckling.Dimensions.Types
 
-allDimensions :: [Some Dimension]
+allDimensions :: [Seal Dimension]
 allDimensions =
-  [ This Distance
-  , This Duration
-  , This Numeral
-  , This Ordinal
-  , This Time
-  , This Volume
+  [ Seal Distance
+  , Seal Duration
+  , Seal Numeral
+  , Seal Ordinal
+  , Seal Time
+  , Seal Volume
   ]

--- a/Duckling/Dimensions/EL.hs
+++ b/Duckling/Dimensions/EL.hs
@@ -11,10 +11,10 @@ module Duckling.Dimensions.EL
 
 import Duckling.Dimensions.Types
 
-allDimensions :: [Some Dimension]
+allDimensions :: [Seal Dimension]
 allDimensions =
-  [ This Duration
-  , This Numeral
-  , This Ordinal
-  , This Time
+  [ Seal Duration
+  , Seal Numeral
+  , Seal Ordinal
+  , Seal Time
   ]

--- a/Duckling/Dimensions/EN.hs
+++ b/Duckling/Dimensions/EN.hs
@@ -11,14 +11,14 @@ module Duckling.Dimensions.EN
 
 import Duckling.Dimensions.Types
 
-allDimensions :: [Some Dimension]
+allDimensions :: [Seal Dimension]
 allDimensions =
-  [ This Distance
-  , This Duration
-  , This Numeral
-  , This Ordinal
-  , This Quantity
-  , This Temperature
-  , This Time
-  , This Volume
+  [ Seal Distance
+  , Seal Duration
+  , Seal Numeral
+  , Seal Ordinal
+  , Seal Quantity
+  , Seal Temperature
+  , Seal Time
+  , Seal Volume
   ]

--- a/Duckling/Dimensions/ES.hs
+++ b/Duckling/Dimensions/ES.hs
@@ -11,13 +11,13 @@ module Duckling.Dimensions.ES
 
 import Duckling.Dimensions.Types
 
-allDimensions :: [Some Dimension]
+allDimensions :: [Seal Dimension]
 allDimensions =
-  [ This Distance
-  , This Duration
-  , This Numeral
-  , This Ordinal
-  , This Temperature
-  , This Time
-  , This Volume
+  [ Seal Distance
+  , Seal Duration
+  , Seal Numeral
+  , Seal Ordinal
+  , Seal Temperature
+  , Seal Time
+  , Seal Volume
   ]

--- a/Duckling/Dimensions/ET.hs
+++ b/Duckling/Dimensions/ET.hs
@@ -11,8 +11,8 @@ module Duckling.Dimensions.ET
 
 import Duckling.Dimensions.Types
 
-allDimensions :: [Some Dimension]
+allDimensions :: [Seal Dimension]
 allDimensions =
-  [ This Numeral
-  , This Ordinal
+  [ Seal Numeral
+  , Seal Ordinal
   ]

--- a/Duckling/Dimensions/FI.hs
+++ b/Duckling/Dimensions/FI.hs
@@ -10,7 +10,7 @@ module Duckling.Dimensions.FI
 
 import Duckling.Dimensions.Types
 
-allDimensions :: [Some Dimension]
+allDimensions :: [Seal Dimension]
 allDimensions  =
-  [ This Numeral
+  [ Seal Numeral
   ]

--- a/Duckling/Dimensions/FR.hs
+++ b/Duckling/Dimensions/FR.hs
@@ -11,14 +11,14 @@ module Duckling.Dimensions.FR
 
 import Duckling.Dimensions.Types
 
-allDimensions :: [Some Dimension]
+allDimensions :: [Seal Dimension]
 allDimensions =
-  [ This Distance
-  , This Duration
-  , This Numeral
-  , This Ordinal
-  , This Quantity
-  , This Temperature
-  , This Time
-  , This Volume
+  [ Seal Distance
+  , Seal Duration
+  , Seal Numeral
+  , Seal Ordinal
+  , Seal Quantity
+  , Seal Temperature
+  , Seal Time
+  , Seal Volume
   ]

--- a/Duckling/Dimensions/GA.hs
+++ b/Duckling/Dimensions/GA.hs
@@ -11,13 +11,13 @@ module Duckling.Dimensions.GA
 
 import Duckling.Dimensions.Types
 
-allDimensions :: [Some Dimension]
+allDimensions :: [Seal Dimension]
 allDimensions =
-  [ This Distance
-  , This Duration
-  , This Numeral
-  , This Ordinal
-  , This Temperature
-  , This Time
-  , This Volume
+  [ Seal Distance
+  , Seal Duration
+  , Seal Numeral
+  , Seal Ordinal
+  , Seal Temperature
+  , Seal Time
+  , Seal Volume
   ]

--- a/Duckling/Dimensions/HE.hs
+++ b/Duckling/Dimensions/HE.hs
@@ -11,10 +11,10 @@ module Duckling.Dimensions.HE
 
 import Duckling.Dimensions.Types
 
-allDimensions :: [Some Dimension]
+allDimensions :: [Seal Dimension]
 allDimensions =
-  [ This Duration
-  , This Numeral
-  , This Ordinal
-  , This Time
+  [ Seal Duration
+  , Seal Numeral
+  , Seal Ordinal
+  , Seal Time
   ]

--- a/Duckling/Dimensions/HI.hs
+++ b/Duckling/Dimensions/HI.hs
@@ -11,10 +11,10 @@ module Duckling.Dimensions.HI
 
 import Duckling.Dimensions.Types
 
-allDimensions :: [Some Dimension]
+allDimensions :: [Seal Dimension]
 allDimensions =
-  [ This Duration
-  , This Numeral
-  , This Ordinal
-  , This Temperature
+  [ Seal Duration
+  , Seal Numeral
+  , Seal Ordinal
+  , Seal Temperature
   ]

--- a/Duckling/Dimensions/HR.hs
+++ b/Duckling/Dimensions/HR.hs
@@ -11,14 +11,14 @@ module Duckling.Dimensions.HR
 
 import Duckling.Dimensions.Types
 
-allDimensions :: [Some Dimension]
+allDimensions :: [Seal Dimension]
 allDimensions =
-  [ This Distance
-  , This Duration
-  , This Numeral
-  , This Ordinal
-  , This Quantity
-  , This Temperature
-  , This Time
-  , This Volume
+  [ Seal Distance
+  , Seal Duration
+  , Seal Numeral
+  , Seal Ordinal
+  , Seal Quantity
+  , Seal Temperature
+  , Seal Time
+  , Seal Volume
   ]

--- a/Duckling/Dimensions/HU.hs
+++ b/Duckling/Dimensions/HU.hs
@@ -11,10 +11,10 @@ module Duckling.Dimensions.HU
 
 import Duckling.Dimensions.Types
 
-allDimensions :: [Some Dimension]
+allDimensions :: [Seal Dimension]
 allDimensions =
-  [ This Duration
-  , This Numeral
-  , This Ordinal
-  , This Time
+  [ Seal Duration
+  , Seal Numeral
+  , Seal Ordinal
+  , Seal Time
   ]

--- a/Duckling/Dimensions/ID.hs
+++ b/Duckling/Dimensions/ID.hs
@@ -11,8 +11,8 @@ module Duckling.Dimensions.ID
 
 import Duckling.Dimensions.Types
 
-allDimensions :: [Some Dimension]
+allDimensions :: [Seal Dimension]
 allDimensions =
-  [ This Numeral
-  , This Ordinal
+  [ Seal Numeral
+  , Seal Ordinal
   ]

--- a/Duckling/Dimensions/IS.hs
+++ b/Duckling/Dimensions/IS.hs
@@ -11,7 +11,7 @@ module Duckling.Dimensions.IS
 
 import Duckling.Dimensions.Types
 
-allDimensions :: [Some Dimension]
+allDimensions :: [Seal Dimension]
 allDimensions =
-  [ This Numeral
+  [ Seal Numeral
   ]

--- a/Duckling/Dimensions/IT.hs
+++ b/Duckling/Dimensions/IT.hs
@@ -11,13 +11,13 @@ module Duckling.Dimensions.IT
 
 import Duckling.Dimensions.Types
 
-allDimensions :: [Some Dimension]
+allDimensions :: [Seal Dimension]
 allDimensions =
-  [ This Distance
-  , This Duration
-  , This Numeral
-  , This Ordinal
-  , This Temperature
-  , This Time
-  , This Volume
+  [ Seal Distance
+  , Seal Duration
+  , Seal Numeral
+  , Seal Ordinal
+  , Seal Temperature
+  , Seal Time
+  , Seal Volume
   ]

--- a/Duckling/Dimensions/JA.hs
+++ b/Duckling/Dimensions/JA.hs
@@ -11,10 +11,10 @@ module Duckling.Dimensions.JA
 
 import Duckling.Dimensions.Types
 
-allDimensions :: [Some Dimension]
+allDimensions :: [Seal Dimension]
 allDimensions =
-  [ This Duration
-  , This Numeral
-  , This Ordinal
-  , This Temperature
+  [ Seal Duration
+  , Seal Numeral
+  , Seal Ordinal
+  , Seal Temperature
   ]

--- a/Duckling/Dimensions/KA.hs
+++ b/Duckling/Dimensions/KA.hs
@@ -11,10 +11,10 @@ module Duckling.Dimensions.KA
 
 import Duckling.Dimensions.Types
 
-allDimensions :: [Some Dimension]
+allDimensions :: [Seal Dimension]
 allDimensions =
-  [ This Numeral
-  , This Ordinal
-  , This Duration
-  , This Time
+  [ Seal Numeral
+  , Seal Ordinal
+  , Seal Duration
+  , Seal Time
   ]

--- a/Duckling/Dimensions/KM.hs
+++ b/Duckling/Dimensions/KM.hs
@@ -11,12 +11,12 @@ module Duckling.Dimensions.KM
 
 import Duckling.Dimensions.Types
 
-allDimensions :: [Some Dimension]
+allDimensions :: [Seal Dimension]
 allDimensions =
-  [ This Distance
-  , This Numeral
-  , This Ordinal
-  , This Quantity
-  , This Temperature
-  , This Volume
+  [ Seal Distance
+  , Seal Numeral
+  , Seal Ordinal
+  , Seal Quantity
+  , Seal Temperature
+  , Seal Volume
   ]

--- a/Duckling/Dimensions/KN.hs
+++ b/Duckling/Dimensions/KN.hs
@@ -11,7 +11,7 @@ module Duckling.Dimensions.KN
 
 import Duckling.Dimensions.Types
 
-allDimensions :: [Some Dimension]
+allDimensions :: [Seal Dimension]
 allDimensions =
-  [ This Numeral
+  [ Seal Numeral
   ]

--- a/Duckling/Dimensions/KO.hs
+++ b/Duckling/Dimensions/KO.hs
@@ -11,14 +11,14 @@ module Duckling.Dimensions.KO
 
 import Duckling.Dimensions.Types
 
-allDimensions :: [Some Dimension]
+allDimensions :: [Seal Dimension]
 allDimensions =
-  [ This Distance
-  , This Duration
-  , This Numeral
-  , This Ordinal
-  , This Quantity
-  , This Temperature
-  , This Time
-  , This Volume
+  [ Seal Distance
+  , Seal Duration
+  , Seal Numeral
+  , Seal Ordinal
+  , Seal Quantity
+  , Seal Temperature
+  , Seal Time
+  , Seal Volume
   ]

--- a/Duckling/Dimensions/LO.hs
+++ b/Duckling/Dimensions/LO.hs
@@ -11,7 +11,7 @@ module Duckling.Dimensions.LO
 
 import Duckling.Dimensions.Types
 
-allDimensions :: [Some Dimension]
+allDimensions :: [Seal Dimension]
 allDimensions =
-  [ This Numeral
+  [ Seal Numeral
   ]

--- a/Duckling/Dimensions/ML.hs
+++ b/Duckling/Dimensions/ML.hs
@@ -11,8 +11,8 @@ module Duckling.Dimensions.ML
 
 import Duckling.Dimensions.Types
 
-allDimensions :: [Some Dimension]
+allDimensions :: [Seal Dimension]
 allDimensions =
-  [ This Numeral,
-    This Ordinal
+  [ Seal Numeral,
+    Seal Ordinal
   ]

--- a/Duckling/Dimensions/MN.hs
+++ b/Duckling/Dimensions/MN.hs
@@ -11,13 +11,13 @@ module Duckling.Dimensions.MN
 
 import Duckling.Dimensions.Types
 
-allDimensions :: [Some Dimension]
+allDimensions :: [Seal Dimension]
 allDimensions =
-  [ This Distance
-  , This Duration
-  , This Numeral
-  , This Ordinal
-  , This Quantity
-  , This Temperature
-  , This Volume
+  [ Seal Distance
+  , Seal Duration
+  , Seal Numeral
+  , Seal Ordinal
+  , Seal Quantity
+  , Seal Temperature
+  , Seal Volume
   ]

--- a/Duckling/Dimensions/MY.hs
+++ b/Duckling/Dimensions/MY.hs
@@ -11,7 +11,7 @@ module Duckling.Dimensions.MY
 
 import Duckling.Dimensions.Types
 
-allDimensions :: [Some Dimension]
+allDimensions :: [Seal Dimension]
 allDimensions =
-  [ This Numeral
+  [ Seal Numeral
   ]

--- a/Duckling/Dimensions/NB.hs
+++ b/Duckling/Dimensions/NB.hs
@@ -11,10 +11,10 @@ module Duckling.Dimensions.NB
 
 import Duckling.Dimensions.Types
 
-allDimensions :: [Some Dimension]
+allDimensions :: [Seal Dimension]
 allDimensions =
-  [ This Duration
-  , This Numeral
-  , This Ordinal
-  , This Time
+  [ Seal Duration
+  , Seal Numeral
+  , Seal Ordinal
+  , Seal Time
   ]

--- a/Duckling/Dimensions/NE.hs
+++ b/Duckling/Dimensions/NE.hs
@@ -11,7 +11,7 @@ module Duckling.Dimensions.NE
 
 import Duckling.Dimensions.Types
 
-allDimensions :: [Some Dimension]
+allDimensions :: [Seal Dimension]
 allDimensions =
-  [ This Numeral
+  [ Seal Numeral
   ]

--- a/Duckling/Dimensions/NL.hs
+++ b/Duckling/Dimensions/NL.hs
@@ -11,13 +11,13 @@ module Duckling.Dimensions.NL
 
 import Duckling.Dimensions.Types
 
-allDimensions :: [Some Dimension]
+allDimensions :: [Seal Dimension]
 allDimensions =
-  [ This Distance
-  , This Duration
-  , This Numeral
-  , This Ordinal
-  , This Quantity
-  , This Time
-  , This Volume
+  [ Seal Distance
+  , Seal Duration
+  , Seal Numeral
+  , Seal Ordinal
+  , Seal Quantity
+  , Seal Time
+  , Seal Volume
   ]

--- a/Duckling/Dimensions/PL.hs
+++ b/Duckling/Dimensions/PL.hs
@@ -11,10 +11,10 @@ module Duckling.Dimensions.PL
 
 import Duckling.Dimensions.Types
 
-allDimensions :: [Some Dimension]
+allDimensions :: [Seal Dimension]
 allDimensions =
-  [ This Duration
-  , This Numeral
-  , This Ordinal
-  , This Time
+  [ Seal Duration
+  , Seal Numeral
+  , Seal Ordinal
+  , Seal Time
   ]

--- a/Duckling/Dimensions/PT.hs
+++ b/Duckling/Dimensions/PT.hs
@@ -11,14 +11,14 @@ module Duckling.Dimensions.PT
 
 import Duckling.Dimensions.Types
 
-allDimensions :: [Some Dimension]
+allDimensions :: [Seal Dimension]
 allDimensions =
-  [ This Distance
-  , This Duration
-  , This Numeral
-  , This Ordinal
-  , This Quantity
-  , This Temperature
-  , This Time
-  , This Volume
+  [ Seal Distance
+  , Seal Duration
+  , Seal Numeral
+  , Seal Ordinal
+  , Seal Quantity
+  , Seal Temperature
+  , Seal Time
+  , Seal Volume
   ]

--- a/Duckling/Dimensions/RO.hs
+++ b/Duckling/Dimensions/RO.hs
@@ -11,14 +11,14 @@ module Duckling.Dimensions.RO
 
 import Duckling.Dimensions.Types
 
-allDimensions :: [Some Dimension]
+allDimensions :: [Seal Dimension]
 allDimensions =
-  [ This Distance
-  , This Duration
-  , This Numeral
-  , This Ordinal
-  , This Quantity
-  , This Temperature
-  , This Time
-  , This Volume
+  [ Seal Distance
+  , Seal Duration
+  , Seal Numeral
+  , Seal Ordinal
+  , Seal Quantity
+  , Seal Temperature
+  , Seal Time
+  , Seal Volume
   ]

--- a/Duckling/Dimensions/RU.hs
+++ b/Duckling/Dimensions/RU.hs
@@ -11,12 +11,12 @@ module Duckling.Dimensions.RU
 
 import Duckling.Dimensions.Types
 
-allDimensions :: [Some Dimension]
+allDimensions :: [Seal Dimension]
 allDimensions =
-  [ This Distance
-  , This Duration
-  , This Numeral
-  , This Ordinal
-  , This Quantity
-  , This Volume
+  [ Seal Distance
+  , Seal Duration
+  , Seal Numeral
+  , Seal Ordinal
+  , Seal Quantity
+  , Seal Volume
   ]

--- a/Duckling/Dimensions/SK.hs
+++ b/Duckling/Dimensions/SK.hs
@@ -12,7 +12,7 @@ module Duckling.Dimensions.SK
 
 import Duckling.Dimensions.Types
 
-allDimensions :: [Some Dimension]
+allDimensions :: [Seal Dimension]
 allDimensions =
-  [ This Numeral
+  [ Seal Numeral
   ]

--- a/Duckling/Dimensions/SV.hs
+++ b/Duckling/Dimensions/SV.hs
@@ -11,11 +11,11 @@ module Duckling.Dimensions.SV
 
 import Duckling.Dimensions.Types
 
-allDimensions :: [Some Dimension]
+allDimensions :: [Seal Dimension]
 allDimensions =
-  [ This Distance
-  , This Duration
-  , This Numeral
-  , This Ordinal
-  , This Time
+  [ Seal Distance
+  , Seal Duration
+  , Seal Numeral
+  , Seal Ordinal
+  , Seal Time
   ]

--- a/Duckling/Dimensions/SW.hs
+++ b/Duckling/Dimensions/SW.hs
@@ -11,7 +11,7 @@ module Duckling.Dimensions.SW
 
 import Duckling.Dimensions.Types
 
-allDimensions :: [Some Dimension]
+allDimensions :: [Seal Dimension]
 allDimensions =
-  [ This Numeral
+  [ Seal Numeral
   ]

--- a/Duckling/Dimensions/TA.hs
+++ b/Duckling/Dimensions/TA.hs
@@ -11,8 +11,8 @@ module Duckling.Dimensions.TA
 
 import Duckling.Dimensions.Types
 
-allDimensions :: [Some Dimension]
+allDimensions :: [Seal Dimension]
 allDimensions =
-  [ This Numeral
-  , This Ordinal
+  [ Seal Numeral
+  , Seal Ordinal
   ]

--- a/Duckling/Dimensions/TH.hs
+++ b/Duckling/Dimensions/TH.hs
@@ -11,7 +11,7 @@ module Duckling.Dimensions.TH
 
 import Duckling.Dimensions.Types
 
-allDimensions :: [Some Dimension]
+allDimensions :: [Seal Dimension]
 allDimensions =
-  [ This Numeral
+  [ Seal Numeral
   ]

--- a/Duckling/Dimensions/TR.hs
+++ b/Duckling/Dimensions/TR.hs
@@ -11,12 +11,12 @@ module Duckling.Dimensions.TR
 
 import Duckling.Dimensions.Types
 
-allDimensions :: [Some Dimension]
+allDimensions :: [Seal Dimension]
 allDimensions =
-  [ This Distance
-  , This Duration
-  , This Numeral
-  , This Ordinal
-  , This Temperature
-  , This Volume
+  [ Seal Distance
+  , Seal Duration
+  , Seal Numeral
+  , Seal Ordinal
+  , Seal Temperature
+  , Seal Volume
   ]

--- a/Duckling/Dimensions/Types.hs
+++ b/Duckling/Dimensions/Types.hs
@@ -10,7 +10,7 @@
 
 
 module Duckling.Dimensions.Types
-  ( Some(..)
+  ( Seal(..)
   , Dimension(..)
 
   , fromName
@@ -18,7 +18,6 @@ module Duckling.Dimensions.Types
   ) where
 
 import Data.Maybe
-import Data.Some
 import Data.Text (Text)
 import Prelude
 import qualified Data.HashMap.Strict as HashMap
@@ -44,22 +43,22 @@ toName Url = "url"
 toName Volume = "volume"
 toName (CustomDimension dim) = Text.pack (show dim)
 
-fromName :: Text -> Maybe (Some Dimension)
+fromName :: Text -> Maybe (Seal Dimension)
 fromName name = HashMap.lookup name m
   where
     m = HashMap.fromList
-      [ ("amount-of-money", This AmountOfMoney)
-      , ("credit-card-number", This CreditCardNumber)
-      , ("distance", This Distance)
-      , ("duration", This Duration)
-      , ("email", This Email)
-      , ("number", This Numeral)
-      , ("ordinal", This Ordinal)
-      , ("phone-number", This PhoneNumber)
-      , ("quantity", This Quantity)
-      , ("temperature", This Temperature)
-      , ("time", This Time)
-      , ("time-grain", This TimeGrain)
-      , ("url", This Url)
-      , ("volume", This Volume)
+      [ ("amount-of-money", Seal AmountOfMoney)
+      , ("credit-card-number", Seal CreditCardNumber)
+      , ("distance", Seal Distance)
+      , ("duration", Seal Duration)
+      , ("email", Seal Email)
+      , ("number", Seal Numeral)
+      , ("ordinal", Seal Ordinal)
+      , ("phone-number", Seal PhoneNumber)
+      , ("quantity", Seal Quantity)
+      , ("temperature", Seal Temperature)
+      , ("time", Seal Time)
+      , ("time-grain", Seal TimeGrain)
+      , ("url", Seal Url)
+      , ("volume", Seal Volume)
       ]

--- a/Duckling/Dimensions/UK.hs
+++ b/Duckling/Dimensions/UK.hs
@@ -11,10 +11,10 @@ module Duckling.Dimensions.UK
 
 import Duckling.Dimensions.Types
 
-allDimensions :: [Some Dimension]
+allDimensions :: [Seal Dimension]
 allDimensions =
-  [ This Duration
-  , This Numeral
-  , This Ordinal
-  , This Time
+  [ Seal Duration
+  , Seal Numeral
+  , Seal Ordinal
+  , Seal Time
   ]

--- a/Duckling/Dimensions/VI.hs
+++ b/Duckling/Dimensions/VI.hs
@@ -11,10 +11,10 @@ module Duckling.Dimensions.VI
 
 import Duckling.Dimensions.Types
 
-allDimensions :: [Some Dimension]
+allDimensions :: [Seal Dimension]
 allDimensions =
-  [ This Duration
-  , This Numeral
-  , This Ordinal
-  , This Time
+  [ Seal Duration
+  , Seal Numeral
+  , Seal Ordinal
+  , Seal Time
   ]

--- a/Duckling/Dimensions/ZH.hs
+++ b/Duckling/Dimensions/ZH.hs
@@ -11,13 +11,13 @@ module Duckling.Dimensions.ZH
 
 import Duckling.Dimensions.Types
 
-allDimensions :: [Some Dimension]
+allDimensions :: [Seal Dimension]
 allDimensions =
-  [ This Distance
-  , This Duration
-  , This Numeral
-  , This Ordinal
-  , This Quantity
-  , This Temperature
-  , This Time
+  [ Seal Distance
+  , Seal Duration
+  , Seal Numeral
+  , Seal Ordinal
+  , Seal Quantity
+  , Seal Temperature
+  , Seal Time
   ]

--- a/Duckling/Ranking/Rank.hs
+++ b/Duckling/Ranking/Rank.hs
@@ -53,7 +53,7 @@ winners xs = filter (\x -> all ((/=) LT . compare x) xs) xs
 -- | Return a curated list of tokens
 rank
   :: Classifiers
-  -> HashSet (Some Dimension)
+  -> HashSet (Seal Dimension)
   -> [ResolvedToken]
   -> [ResolvedToken]
 rank classifiers targets tokens =
@@ -64,4 +64,4 @@ rank classifiers targets tokens =
   where
     makeCandidate :: ResolvedToken -> Candidate
     makeCandidate token@Resolved {node = n@Node {token = Token d _}} =
-      Candidate token (score classifiers n) $ HashSet.member (This d) targets
+      Candidate token (score classifiers n) $ HashSet.member (Seal d) targets

--- a/Duckling/Rules.hs
+++ b/Duckling/Rules.hs
@@ -70,7 +70,7 @@ import qualified Duckling.Rules.VI as VIRules
 import qualified Duckling.Rules.ZH as ZHRules
 
 -- | Returns the minimal set of rules required for `targets`.
-rulesFor :: Locale -> HashSet (Some Dimension) -> [Rule]
+rulesFor :: Locale -> HashSet (Seal Dimension) -> [Rule]
 rulesFor locale targets
   | HashSet.null targets = allRules locale
   | otherwise = [ rules | dims <- HashSet.toList $ explicitDimensions targets
@@ -82,14 +82,14 @@ allRules :: Locale -> [Rule]
 allRules locale@(Locale lang _) = concatMap (rulesFor' locale) . HashSet.toList
   . explicitDimensions . HashSet.fromList $ allDimensions lang
 
-rulesFor' :: Locale -> Some Dimension -> [Rule]
+rulesFor' :: Locale -> Seal Dimension -> [Rule]
 rulesFor' (Locale lang (Just region)) dim =
   CommonRules.rules dim ++ langRules lang dim ++ localeRules lang region dim
 rulesFor' (Locale lang Nothing) dim =
   CommonRules.rules dim ++ defaultRules lang dim
 
 -- | Default rules when no locale, for backward compatibility.
-defaultRules :: Lang -> Some Dimension -> [Rule]
+defaultRules :: Lang -> Seal Dimension -> [Rule]
 defaultRules AF = AFRules.defaultRules
 defaultRules AR = ARRules.defaultRules
 defaultRules BG = BGRules.defaultRules
@@ -137,7 +137,7 @@ defaultRules UK = UKRules.defaultRules
 defaultRules VI = VIRules.defaultRules
 defaultRules ZH = ZHRules.defaultRules
 
-localeRules :: Lang -> Region -> Some Dimension -> [Rule]
+localeRules :: Lang -> Region -> Seal Dimension -> [Rule]
 localeRules AF = AFRules.localeRules
 localeRules AR = ARRules.localeRules
 localeRules BG = BGRules.localeRules
@@ -185,7 +185,7 @@ localeRules UK = UKRules.localeRules
 localeRules VI = VIRules.localeRules
 localeRules ZH = ZHRules.localeRules
 
-langRules :: Lang -> Some Dimension -> [Rule]
+langRules :: Lang -> Seal Dimension -> [Rule]
 langRules AF = AFRules.langRules
 langRules AR = ARRules.langRules
 langRules BG = BGRules.langRules

--- a/Duckling/Rules/AF.hs
+++ b/Duckling/Rules/AF.hs
@@ -19,27 +19,27 @@ import Duckling.Locale
 import Duckling.Types
 import qualified Duckling.Numeral.AF.Rules as Numeral
 
-defaultRules :: Some Dimension -> [Rule]
+defaultRules :: Seal Dimension -> [Rule]
 defaultRules = langRules
 
-localeRules :: Region -> Some Dimension -> [Rule]
-localeRules region (This (CustomDimension dim)) = dimLocaleRules region dim
+localeRules :: Region -> Seal Dimension -> [Rule]
+localeRules region (Seal (CustomDimension dim)) = dimLocaleRules region dim
 localeRules _ _ = []
 
-langRules :: Some Dimension -> [Rule]
-langRules (This AmountOfMoney) = []
-langRules (This CreditCardNumber) = []
-langRules (This Distance) = []
-langRules (This Duration) = []
-langRules (This Email) = []
-langRules (This Numeral) = Numeral.rules
-langRules (This Ordinal) = []
-langRules (This PhoneNumber) = []
-langRules (This Quantity) = []
-langRules (This RegexMatch) = []
-langRules (This Temperature) = []
-langRules (This Time) = []
-langRules (This TimeGrain) = []
-langRules (This Url) = []
-langRules (This Volume) = []
-langRules (This (CustomDimension dim)) = dimLangRules AF dim
+langRules :: Seal Dimension -> [Rule]
+langRules (Seal AmountOfMoney) = []
+langRules (Seal CreditCardNumber) = []
+langRules (Seal Distance) = []
+langRules (Seal Duration) = []
+langRules (Seal Email) = []
+langRules (Seal Numeral) = Numeral.rules
+langRules (Seal Ordinal) = []
+langRules (Seal PhoneNumber) = []
+langRules (Seal Quantity) = []
+langRules (Seal RegexMatch) = []
+langRules (Seal Temperature) = []
+langRules (Seal Time) = []
+langRules (Seal TimeGrain) = []
+langRules (Seal Url) = []
+langRules (Seal Volume) = []
+langRules (Seal (CustomDimension dim)) = dimLangRules AF dim

--- a/Duckling/Rules/AR.hs
+++ b/Duckling/Rules/AR.hs
@@ -28,27 +28,27 @@ import qualified Duckling.Time.AR.Rules as Time
 import qualified Duckling.TimeGrain.AR.Rules as TimeGrain
 import qualified Duckling.Volume.AR.Rules as Volume
 
-defaultRules :: Some Dimension -> [Rule]
+defaultRules :: Seal Dimension -> [Rule]
 defaultRules = langRules
 
-localeRules :: Region -> Some Dimension -> [Rule]
-localeRules region (This (CustomDimension dim)) = dimLocaleRules region dim
+localeRules :: Region -> Seal Dimension -> [Rule]
+localeRules region (Seal (CustomDimension dim)) = dimLocaleRules region dim
 localeRules _ _ = []
 
-langRules :: Some Dimension -> [Rule]
-langRules (This AmountOfMoney) = AmountOfMoney.rules
-langRules (This CreditCardNumber) = []
-langRules (This Distance) = []
-langRules (This Duration) = Duration.rules
-langRules (This Email) = []
-langRules (This Numeral) = Numeral.rules
-langRules (This Ordinal) = Ordinal.rules
-langRules (This PhoneNumber) = PhoneNumber.rules
-langRules (This Quantity) = Quantity.rules
-langRules (This RegexMatch) = []
-langRules (This Temperature) = Temperature.rules
-langRules (This Time) = Time.rules
-langRules (This TimeGrain) = TimeGrain.rules
-langRules (This Url) = []
-langRules (This Volume) = Volume.rules
-langRules (This (CustomDimension dim)) = dimLangRules AR dim
+langRules :: Seal Dimension -> [Rule]
+langRules (Seal AmountOfMoney) = AmountOfMoney.rules
+langRules (Seal CreditCardNumber) = []
+langRules (Seal Distance) = []
+langRules (Seal Duration) = Duration.rules
+langRules (Seal Email) = []
+langRules (Seal Numeral) = Numeral.rules
+langRules (Seal Ordinal) = Ordinal.rules
+langRules (Seal PhoneNumber) = PhoneNumber.rules
+langRules (Seal Quantity) = Quantity.rules
+langRules (Seal RegexMatch) = []
+langRules (Seal Temperature) = Temperature.rules
+langRules (Seal Time) = Time.rules
+langRules (Seal TimeGrain) = TimeGrain.rules
+langRules (Seal Url) = []
+langRules (Seal Volume) = Volume.rules
+langRules (Seal (CustomDimension dim)) = dimLangRules AR dim

--- a/Duckling/Rules/BG.hs
+++ b/Duckling/Rules/BG.hs
@@ -25,27 +25,27 @@ import qualified Duckling.Time.BG.Rules as Time
 import qualified Duckling.TimeGrain.BG.Rules as TimeGrain
 import qualified Duckling.Ordinal.BG.Rules as Ordinal
 
-defaultRules :: Some Dimension -> [Rule]
+defaultRules :: Seal Dimension -> [Rule]
 defaultRules = langRules
 
-localeRules :: Region -> Some Dimension -> [Rule]
-localeRules region (This (CustomDimension dim)) = dimLocaleRules region dim
+localeRules :: Region -> Seal Dimension -> [Rule]
+localeRules region (Seal (CustomDimension dim)) = dimLocaleRules region dim
 localeRules _ _ = []
 
-langRules :: Some Dimension -> [Rule]
-langRules (This AmountOfMoney) = AmountOfMoney.rules
-langRules (This CreditCardNumber) = []
-langRules (This Distance) = Distance.rules
-langRules (This Duration) = Duration.rules
-langRules (This Email) = []
-langRules (This Numeral) = Numeral.rules
-langRules (This Ordinal) = Ordinal.rules
-langRules (This PhoneNumber) = []
-langRules (This Quantity) = []
-langRules (This RegexMatch) = []
-langRules (This Temperature) = []
-langRules (This Time) = Time.rules
-langRules (This TimeGrain) = TimeGrain.rules
-langRules (This Url) = []
-langRules (This Volume) = []
-langRules (This (CustomDimension dim)) = dimLangRules BG dim
+langRules :: Seal Dimension -> [Rule]
+langRules (Seal AmountOfMoney) = AmountOfMoney.rules
+langRules (Seal CreditCardNumber) = []
+langRules (Seal Distance) = Distance.rules
+langRules (Seal Duration) = Duration.rules
+langRules (Seal Email) = []
+langRules (Seal Numeral) = Numeral.rules
+langRules (Seal Ordinal) = Ordinal.rules
+langRules (Seal PhoneNumber) = []
+langRules (Seal Quantity) = []
+langRules (Seal RegexMatch) = []
+langRules (Seal Temperature) = []
+langRules (Seal Time) = Time.rules
+langRules (Seal TimeGrain) = TimeGrain.rules
+langRules (Seal Url) = []
+langRules (Seal Volume) = []
+langRules (Seal (CustomDimension dim)) = dimLangRules BG dim

--- a/Duckling/Rules/BN.hs
+++ b/Duckling/Rules/BN.hs
@@ -18,27 +18,27 @@ import Duckling.Locale
 import Duckling.Types
 import qualified Duckling.Numeral.BN.Rules as Numeral
 
-defaultRules :: Some Dimension -> [Rule]
+defaultRules :: Seal Dimension -> [Rule]
 defaultRules = langRules
 
-localeRules :: Region -> Some Dimension -> [Rule]
-localeRules region (This (CustomDimension dim)) = dimLocaleRules region dim
+localeRules :: Region -> Seal Dimension -> [Rule]
+localeRules region (Seal (CustomDimension dim)) = dimLocaleRules region dim
 localeRules _ _ = []
 
-langRules :: Some Dimension -> [Rule]
-langRules (This AmountOfMoney) = []
-langRules (This CreditCardNumber) = []
-langRules (This Distance) = []
-langRules (This Duration) = []
-langRules (This Numeral) = Numeral.rules
-langRules (This Email) = []
-langRules (This Ordinal) = []
-langRules (This PhoneNumber) = []
-langRules (This Quantity) = []
-langRules (This RegexMatch) = []
-langRules (This Temperature) = []
-langRules (This Time) = []
-langRules (This TimeGrain) = []
-langRules (This Url) = []
-langRules (This Volume) = []
-langRules (This (CustomDimension dim)) = dimLangRules BN dim
+langRules :: Seal Dimension -> [Rule]
+langRules (Seal AmountOfMoney) = []
+langRules (Seal CreditCardNumber) = []
+langRules (Seal Distance) = []
+langRules (Seal Duration) = []
+langRules (Seal Numeral) = Numeral.rules
+langRules (Seal Email) = []
+langRules (Seal Ordinal) = []
+langRules (Seal PhoneNumber) = []
+langRules (Seal Quantity) = []
+langRules (Seal RegexMatch) = []
+langRules (Seal Temperature) = []
+langRules (Seal Time) = []
+langRules (Seal TimeGrain) = []
+langRules (Seal Url) = []
+langRules (Seal Volume) = []
+langRules (Seal (CustomDimension dim)) = dimLangRules BN dim

--- a/Duckling/Rules/CS.hs
+++ b/Duckling/Rules/CS.hs
@@ -20,27 +20,27 @@ import Duckling.Types
 import qualified Duckling.Distance.CS.Rules as Distance
 import qualified Duckling.Numeral.CS.Rules as Numeral
 
-defaultRules :: Some Dimension -> [Rule]
+defaultRules :: Seal Dimension -> [Rule]
 defaultRules = langRules
 
-localeRules :: Region -> Some Dimension -> [Rule]
-localeRules region (This (CustomDimension dim)) = dimLocaleRules region dim
+localeRules :: Region -> Seal Dimension -> [Rule]
+localeRules region (Seal (CustomDimension dim)) = dimLocaleRules region dim
 localeRules _ _ = []
 
-langRules :: Some Dimension -> [Rule]
-langRules (This AmountOfMoney) = []
-langRules (This CreditCardNumber) = []
-langRules (This Distance) = Distance.rules
-langRules (This Duration) = []
-langRules (This Email) = []
-langRules (This Numeral) = Numeral.rules
-langRules (This Ordinal) = []
-langRules (This PhoneNumber) = []
-langRules (This Quantity) = []
-langRules (This RegexMatch) = []
-langRules (This Temperature) = []
-langRules (This Time) = []
-langRules (This TimeGrain) = []
-langRules (This Url) = []
-langRules (This Volume) = []
-langRules (This (CustomDimension dim)) = dimLangRules CS dim
+langRules :: Seal Dimension -> [Rule]
+langRules (Seal AmountOfMoney) = []
+langRules (Seal CreditCardNumber) = []
+langRules (Seal Distance) = Distance.rules
+langRules (Seal Duration) = []
+langRules (Seal Email) = []
+langRules (Seal Numeral) = Numeral.rules
+langRules (Seal Ordinal) = []
+langRules (Seal PhoneNumber) = []
+langRules (Seal Quantity) = []
+langRules (Seal RegexMatch) = []
+langRules (Seal Temperature) = []
+langRules (Seal Time) = []
+langRules (Seal TimeGrain) = []
+langRules (Seal Url) = []
+langRules (Seal Volume) = []
+langRules (Seal (CustomDimension dim)) = dimLangRules CS dim

--- a/Duckling/Rules/Common.hs
+++ b/Duckling/Rules/Common.hs
@@ -25,20 +25,20 @@ import qualified Duckling.Temperature.Rules as Temperature
 import qualified Duckling.Url.Rules as Url
 import qualified Duckling.Volume.Rules as Volume
 
-rules :: Some Dimension -> [Rule]
-rules (This AmountOfMoney) = AmountOfMoney.rules
-rules (This CreditCardNumber) = CreditCardNumber.rules
-rules (This Distance) = Distance.rules
-rules (This Duration) = Duration.rules
-rules (This Email) = Email.rules
-rules (This Numeral) = Numeral.rules
-rules (This Ordinal) = []
-rules (This PhoneNumber) = PhoneNumber.rules
-rules (This Quantity) = []
-rules (This RegexMatch) = []
-rules (This Temperature) = Temperature.rules
-rules (This Time) = []
-rules (This TimeGrain) = []
-rules (This Url) = Url.rules
-rules (This Volume) = Volume.rules
-rules (This (CustomDimension dim)) = dimRules dim
+rules :: Seal Dimension -> [Rule]
+rules (Seal AmountOfMoney) = AmountOfMoney.rules
+rules (Seal CreditCardNumber) = CreditCardNumber.rules
+rules (Seal Distance) = Distance.rules
+rules (Seal Duration) = Duration.rules
+rules (Seal Email) = Email.rules
+rules (Seal Numeral) = Numeral.rules
+rules (Seal Ordinal) = []
+rules (Seal PhoneNumber) = PhoneNumber.rules
+rules (Seal Quantity) = []
+rules (Seal RegexMatch) = []
+rules (Seal Temperature) = Temperature.rules
+rules (Seal Time) = []
+rules (Seal TimeGrain) = []
+rules (Seal Url) = Url.rules
+rules (Seal Volume) = Volume.rules
+rules (Seal (CustomDimension dim)) = dimRules dim

--- a/Duckling/Rules/DA.hs
+++ b/Duckling/Rules/DA.hs
@@ -23,27 +23,27 @@ import qualified Duckling.Ordinal.DA.Rules as Ordinal
 import qualified Duckling.Time.DA.Rules as Time
 import qualified Duckling.TimeGrain.DA.Rules as TimeGrain
 
-defaultRules :: Some Dimension -> [Rule]
+defaultRules :: Seal Dimension -> [Rule]
 defaultRules = langRules
 
-localeRules :: Region -> Some Dimension -> [Rule]
-localeRules region (This (CustomDimension dim)) = dimLocaleRules region dim
+localeRules :: Region -> Seal Dimension -> [Rule]
+localeRules region (Seal (CustomDimension dim)) = dimLocaleRules region dim
 localeRules _ _ = []
 
-langRules :: Some Dimension -> [Rule]
-langRules (This AmountOfMoney) = []
-langRules (This CreditCardNumber) = []
-langRules (This Distance) = []
-langRules (This Duration) = Duration.rules
-langRules (This Email) = []
-langRules (This Numeral) = Numeral.rules
-langRules (This Ordinal) = Ordinal.rules
-langRules (This PhoneNumber) = []
-langRules (This Quantity) = []
-langRules (This RegexMatch) = []
-langRules (This Temperature) = []
-langRules (This Time) = Time.rules
-langRules (This TimeGrain) = TimeGrain.rules
-langRules (This Url) = []
-langRules (This Volume) = []
-langRules (This (CustomDimension dim)) = dimLangRules DA dim
+langRules :: Seal Dimension -> [Rule]
+langRules (Seal AmountOfMoney) = []
+langRules (Seal CreditCardNumber) = []
+langRules (Seal Distance) = []
+langRules (Seal Duration) = Duration.rules
+langRules (Seal Email) = []
+langRules (Seal Numeral) = Numeral.rules
+langRules (Seal Ordinal) = Ordinal.rules
+langRules (Seal PhoneNumber) = []
+langRules (Seal Quantity) = []
+langRules (Seal RegexMatch) = []
+langRules (Seal Temperature) = []
+langRules (Seal Time) = Time.rules
+langRules (Seal TimeGrain) = TimeGrain.rules
+langRules (Seal Url) = []
+langRules (Seal Volume) = []
+langRules (Seal (CustomDimension dim)) = dimLangRules DA dim

--- a/Duckling/Rules/DE.hs
+++ b/Duckling/Rules/DE.hs
@@ -24,27 +24,27 @@ import qualified Duckling.TimeGrain.DE.Rules as TimeGrain
 import Duckling.Types
 import qualified Duckling.Volume.DE.Rules as Volume
 
-defaultRules :: Some Dimension -> [Rule]
+defaultRules :: Seal Dimension -> [Rule]
 defaultRules = langRules
 
-localeRules :: Region -> Some Dimension -> [Rule]
-localeRules region (This (CustomDimension dim)) = dimLocaleRules region dim
+localeRules :: Region -> Seal Dimension -> [Rule]
+localeRules region (Seal (CustomDimension dim)) = dimLocaleRules region dim
 localeRules _ _ = []
 
-langRules :: Some Dimension -> [Rule]
-langRules (This AmountOfMoney) = []
-langRules (This CreditCardNumber) = []
-langRules (This Distance) = Distance.rules
-langRules (This Duration) = Duration.rules
-langRules (This Email) = Email.rules
-langRules (This Numeral) = Numeral.rules
-langRules (This Ordinal) = Ordinal.rules
-langRules (This PhoneNumber) = []
-langRules (This Quantity) = []
-langRules (This RegexMatch) = []
-langRules (This Temperature) = []
-langRules (This Time) = Time.rules
-langRules (This TimeGrain) = TimeGrain.rules
-langRules (This Url) = []
-langRules (This Volume) = Volume.rules
-langRules (This (CustomDimension dim)) = dimLangRules DE dim
+langRules :: Seal Dimension -> [Rule]
+langRules (Seal AmountOfMoney) = []
+langRules (Seal CreditCardNumber) = []
+langRules (Seal Distance) = Distance.rules
+langRules (Seal Duration) = Duration.rules
+langRules (Seal Email) = Email.rules
+langRules (Seal Numeral) = Numeral.rules
+langRules (Seal Ordinal) = Ordinal.rules
+langRules (Seal PhoneNumber) = []
+langRules (Seal Quantity) = []
+langRules (Seal RegexMatch) = []
+langRules (Seal Temperature) = []
+langRules (Seal Time) = Time.rules
+langRules (Seal TimeGrain) = TimeGrain.rules
+langRules (Seal Url) = []
+langRules (Seal Volume) = Volume.rules
+langRules (Seal (CustomDimension dim)) = dimLangRules DE dim

--- a/Duckling/Rules/EL.hs
+++ b/Duckling/Rules/EL.hs
@@ -23,27 +23,27 @@ import qualified Duckling.Ordinal.EL.Rules as Ordinal
 import qualified Duckling.Time.EL.Rules as Time
 import qualified Duckling.TimeGrain.EL.Rules as TimeGrain
 
-defaultRules :: Some Dimension -> [Rule]
+defaultRules :: Seal Dimension -> [Rule]
 defaultRules = langRules
 
-localeRules :: Region -> Some Dimension -> [Rule]
-localeRules region (This (CustomDimension dim)) = dimLocaleRules region dim
+localeRules :: Region -> Seal Dimension -> [Rule]
+localeRules region (Seal (CustomDimension dim)) = dimLocaleRules region dim
 localeRules _ _ = []
 
-langRules :: Some Dimension -> [Rule]
-langRules (This AmountOfMoney) = []
-langRules (This CreditCardNumber) = []
-langRules (This Distance) = []
-langRules (This Duration) = Duration.rules
-langRules (This Email) = []
-langRules (This Numeral) = Numeral.rules
-langRules (This Ordinal) = Ordinal.rules
-langRules (This PhoneNumber) = []
-langRules (This Quantity) = []
-langRules (This RegexMatch) = []
-langRules (This Temperature) = []
-langRules (This Time) = Time.rules
-langRules (This TimeGrain) = TimeGrain.rules
-langRules (This Url) = []
-langRules (This Volume) = []
-langRules (This (CustomDimension dim)) = dimLangRules EL dim
+langRules :: Seal Dimension -> [Rule]
+langRules (Seal AmountOfMoney) = []
+langRules (Seal CreditCardNumber) = []
+langRules (Seal Distance) = []
+langRules (Seal Duration) = Duration.rules
+langRules (Seal Email) = []
+langRules (Seal Numeral) = Numeral.rules
+langRules (Seal Ordinal) = Ordinal.rules
+langRules (Seal PhoneNumber) = []
+langRules (Seal Quantity) = []
+langRules (Seal RegexMatch) = []
+langRules (Seal Temperature) = []
+langRules (Seal Time) = Time.rules
+langRules (Seal TimeGrain) = TimeGrain.rules
+langRules (Seal Url) = []
+langRules (Seal Volume) = []
+langRules (Seal (CustomDimension dim)) = dimLangRules EL dim

--- a/Duckling/Rules/EN.hs
+++ b/Duckling/Rules/EN.hs
@@ -55,52 +55,52 @@ import qualified Duckling.Time.EN.ZA.Rules as TimeZA
 import qualified Duckling.TimeGrain.EN.Rules as TimeGrain
 import qualified Duckling.Volume.EN.Rules as Volume
 
-defaultRules :: Some Dimension -> [Rule]
-defaultRules dim@(This Time) = TimeUS.rulesBackwardCompatible ++ langRules dim
+defaultRules :: Seal Dimension -> [Rule]
+defaultRules dim@(Seal Time) = TimeUS.rulesBackwardCompatible ++ langRules dim
 defaultRules dim             = langRules dim
 
-localeRules :: Region -> Some Dimension -> [Rule]
-localeRules AU (This AmountOfMoney) = AmountOfMoneyAU.rules
-localeRules BZ (This AmountOfMoney) = AmountOfMoneyBZ.rules
-localeRules CA (This AmountOfMoney) = AmountOfMoneyCA.rules
-localeRules GB (This AmountOfMoney) = AmountOfMoneyGB.rules
-localeRules IE (This AmountOfMoney) = AmountOfMoneyIE.rules
-localeRules IN (This AmountOfMoney) = AmountOfMoneyIN.rules
-localeRules JM (This AmountOfMoney) = AmountOfMoneyJM.rules
-localeRules NZ (This AmountOfMoney) = AmountOfMoneyNZ.rules
-localeRules PH (This AmountOfMoney) = AmountOfMoneyPH.rules
-localeRules TT (This AmountOfMoney) = AmountOfMoneyTT.rules
-localeRules US (This AmountOfMoney) = AmountOfMoneyUS.rules
-localeRules ZA (This AmountOfMoney) = AmountOfMoneyZA.rules
-localeRules AU (This Time) = TimeAU.rules
-localeRules BZ (This Time) = TimeBZ.rules
-localeRules CA (This Time) = TimeCA.rules
-localeRules GB (This Time) = TimeGB.rules
-localeRules IE (This Time) = TimeIE.rules
-localeRules IN (This Time) = TimeIN.rules
-localeRules JM (This Time) = TimeJM.rules
-localeRules NZ (This Time) = TimeNZ.rules
-localeRules PH (This Time) = TimePH.rules
-localeRules TT (This Time) = TimeTT.rules
-localeRules US (This Time) = TimeUS.rules
-localeRules ZA (This Time) = TimeZA.rules
-localeRules region (This (CustomDimension dim)) = dimLocaleRules region dim
+localeRules :: Region -> Seal Dimension -> [Rule]
+localeRules AU (Seal AmountOfMoney) = AmountOfMoneyAU.rules
+localeRules BZ (Seal AmountOfMoney) = AmountOfMoneyBZ.rules
+localeRules CA (Seal AmountOfMoney) = AmountOfMoneyCA.rules
+localeRules GB (Seal AmountOfMoney) = AmountOfMoneyGB.rules
+localeRules IE (Seal AmountOfMoney) = AmountOfMoneyIE.rules
+localeRules IN (Seal AmountOfMoney) = AmountOfMoneyIN.rules
+localeRules JM (Seal AmountOfMoney) = AmountOfMoneyJM.rules
+localeRules NZ (Seal AmountOfMoney) = AmountOfMoneyNZ.rules
+localeRules PH (Seal AmountOfMoney) = AmountOfMoneyPH.rules
+localeRules TT (Seal AmountOfMoney) = AmountOfMoneyTT.rules
+localeRules US (Seal AmountOfMoney) = AmountOfMoneyUS.rules
+localeRules ZA (Seal AmountOfMoney) = AmountOfMoneyZA.rules
+localeRules AU (Seal Time) = TimeAU.rules
+localeRules BZ (Seal Time) = TimeBZ.rules
+localeRules CA (Seal Time) = TimeCA.rules
+localeRules GB (Seal Time) = TimeGB.rules
+localeRules IE (Seal Time) = TimeIE.rules
+localeRules IN (Seal Time) = TimeIN.rules
+localeRules JM (Seal Time) = TimeJM.rules
+localeRules NZ (Seal Time) = TimeNZ.rules
+localeRules PH (Seal Time) = TimePH.rules
+localeRules TT (Seal Time) = TimeTT.rules
+localeRules US (Seal Time) = TimeUS.rules
+localeRules ZA (Seal Time) = TimeZA.rules
+localeRules region (Seal (CustomDimension dim)) = dimLocaleRules region dim
 localeRules _ _ = []
 
-langRules :: Some Dimension -> [Rule]
-langRules (This AmountOfMoney) = AmountOfMoney.rules
-langRules (This CreditCardNumber) = []
-langRules (This Distance) = Distance.rules
-langRules (This Duration) = Duration.rules
-langRules (This Email) = Email.rules
-langRules (This Numeral) = Numeral.rules
-langRules (This Ordinal) = Ordinal.rules
-langRules (This PhoneNumber) = []
-langRules (This Quantity) = Quantity.rules
-langRules (This RegexMatch) = []
-langRules (This Temperature) = Temperature.rules
-langRules (This Time) = Time.rules
-langRules (This TimeGrain) = TimeGrain.rules
-langRules (This Url) = []
-langRules (This Volume) = Volume.rules
-langRules (This (CustomDimension dim)) = dimLangRules EN dim
+langRules :: Seal Dimension -> [Rule]
+langRules (Seal AmountOfMoney) = AmountOfMoney.rules
+langRules (Seal CreditCardNumber) = []
+langRules (Seal Distance) = Distance.rules
+langRules (Seal Duration) = Duration.rules
+langRules (Seal Email) = Email.rules
+langRules (Seal Numeral) = Numeral.rules
+langRules (Seal Ordinal) = Ordinal.rules
+langRules (Seal PhoneNumber) = []
+langRules (Seal Quantity) = Quantity.rules
+langRules (Seal RegexMatch) = []
+langRules (Seal Temperature) = Temperature.rules
+langRules (Seal Time) = Time.rules
+langRules (Seal TimeGrain) = TimeGrain.rules
+langRules (Seal Url) = []
+langRules (Seal Volume) = Volume.rules
+langRules (Seal (CustomDimension dim)) = dimLangRules EN dim

--- a/Duckling/Rules/ES.hs
+++ b/Duckling/Rules/ES.hs
@@ -40,36 +40,36 @@ import Duckling.Types
 import qualified Duckling.Volume.ES.Rules as Volume
 import qualified Duckling.Duration.ES.Rules as Duration
 
-defaultRules :: Some Dimension -> [Rule]
-defaultRules dim@(This Numeral) =
+defaultRules :: Seal Dimension -> [Rule]
+defaultRules dim@(Seal Numeral) =
   NumeralES.rulesBackwardCompatible ++ langRules dim
 defaultRules dim = langRules dim
 
-localeRules :: Region -> Some Dimension -> [Rule]
-localeRules R.AR (This Numeral) = NumeralAR.rules
-localeRules CL (This Numeral) = NumeralCL.rules
-localeRules CO (This Numeral) = NumeralCO.rules
-localeRules R.ES (This Numeral) = NumeralES.rules
-localeRules MX (This Numeral) = NumeralMX.rules
-localeRules PE (This Numeral) = NumeralPE.rules
-localeRules VE (This Numeral) = NumeralVE.rules
-localeRules region (This (CustomDimension dim)) = dimLocaleRules region dim
+localeRules :: Region -> Seal Dimension -> [Rule]
+localeRules R.AR (Seal Numeral) = NumeralAR.rules
+localeRules CL (Seal Numeral) = NumeralCL.rules
+localeRules CO (Seal Numeral) = NumeralCO.rules
+localeRules R.ES (Seal Numeral) = NumeralES.rules
+localeRules MX (Seal Numeral) = NumeralMX.rules
+localeRules PE (Seal Numeral) = NumeralPE.rules
+localeRules VE (Seal Numeral) = NumeralVE.rules
+localeRules region (Seal (CustomDimension dim)) = dimLocaleRules region dim
 localeRules _ _ = []
 
-langRules :: Some Dimension -> [Rule]
-langRules (This AmountOfMoney) = AmountOfMoney.rules
-langRules (This CreditCardNumber) = []
-langRules (This Distance) = Distance.rules
-langRules (This Duration) = Duration.rules
-langRules (This Email) = []
-langRules (This Numeral) = Numeral.rules
-langRules (This Ordinal) = Ordinal.rules
-langRules (This PhoneNumber) = []
-langRules (This Quantity) = []
-langRules (This RegexMatch) = []
-langRules (This Temperature) = Temperature.rules
-langRules (This Time) = Time.rules
-langRules (This TimeGrain) = TimeGrain.rules
-langRules (This Url) = []
-langRules (This Volume) = Volume.rules
-langRules (This (CustomDimension dim)) = dimLangRules ES dim
+langRules :: Seal Dimension -> [Rule]
+langRules (Seal AmountOfMoney) = AmountOfMoney.rules
+langRules (Seal CreditCardNumber) = []
+langRules (Seal Distance) = Distance.rules
+langRules (Seal Duration) = Duration.rules
+langRules (Seal Email) = []
+langRules (Seal Numeral) = Numeral.rules
+langRules (Seal Ordinal) = Ordinal.rules
+langRules (Seal PhoneNumber) = []
+langRules (Seal Quantity) = []
+langRules (Seal RegexMatch) = []
+langRules (Seal Temperature) = Temperature.rules
+langRules (Seal Time) = Time.rules
+langRules (Seal TimeGrain) = TimeGrain.rules
+langRules (Seal Url) = []
+langRules (Seal Volume) = Volume.rules
+langRules (Seal (CustomDimension dim)) = dimLangRules ES dim

--- a/Duckling/Rules/ET.hs
+++ b/Duckling/Rules/ET.hs
@@ -20,27 +20,27 @@ import Duckling.Types
 import qualified Duckling.Numeral.ET.Rules as Numeral
 import qualified Duckling.Ordinal.ET.Rules as Ordinal
 
-defaultRules :: Some Dimension -> [Rule]
+defaultRules :: Seal Dimension -> [Rule]
 defaultRules = langRules
 
-localeRules :: Region -> Some Dimension -> [Rule]
-localeRules region (This (CustomDimension dim)) = dimLocaleRules region dim
+localeRules :: Region -> Seal Dimension -> [Rule]
+localeRules region (Seal (CustomDimension dim)) = dimLocaleRules region dim
 localeRules _ _ = []
 
-langRules :: Some Dimension -> [Rule]
-langRules (This AmountOfMoney) = []
-langRules (This CreditCardNumber) = []
-langRules (This Distance) = []
-langRules (This Duration) = []
-langRules (This Email) = []
-langRules (This Numeral) = Numeral.rules
-langRules (This Ordinal) = Ordinal.rules
-langRules (This PhoneNumber) = []
-langRules (This Quantity) = []
-langRules (This RegexMatch) = []
-langRules (This Temperature) = []
-langRules (This Time) = []
-langRules (This TimeGrain) = []
-langRules (This Url) = []
-langRules (This Volume) = []
-langRules (This (CustomDimension dim)) = dimLangRules ET dim
+langRules :: Seal Dimension -> [Rule]
+langRules (Seal AmountOfMoney) = []
+langRules (Seal CreditCardNumber) = []
+langRules (Seal Distance) = []
+langRules (Seal Duration) = []
+langRules (Seal Email) = []
+langRules (Seal Numeral) = Numeral.rules
+langRules (Seal Ordinal) = Ordinal.rules
+langRules (Seal PhoneNumber) = []
+langRules (Seal Quantity) = []
+langRules (Seal RegexMatch) = []
+langRules (Seal Temperature) = []
+langRules (Seal Time) = []
+langRules (Seal TimeGrain) = []
+langRules (Seal Url) = []
+langRules (Seal Volume) = []
+langRules (Seal (CustomDimension dim)) = dimLangRules ET dim

--- a/Duckling/Rules/FI.hs
+++ b/Duckling/Rules/FI.hs
@@ -18,27 +18,27 @@ import Duckling.Types
 import qualified Duckling.Numeral.FI.Rules as Numeral
 import qualified Duckling.TimeGrain.FI.Rules as TimeGrain
 
-defaultRules :: Some Dimension -> [Rule]
+defaultRules :: Seal Dimension -> [Rule]
 defaultRules = langRules
 
-localeRules :: Region -> Some Dimension -> [Rule]
-localeRules region (This (CustomDimension dim)) = dimLocaleRules region dim
+localeRules :: Region -> Seal Dimension -> [Rule]
+localeRules region (Seal (CustomDimension dim)) = dimLocaleRules region dim
 localeRules _ _ = []
 
-langRules :: Some Dimension -> [Rule]
-langRules (This AmountOfMoney) = []
-langRules (This CreditCardNumber) = []
-langRules (This Distance) = []
-langRules (This Duration) = []
-langRules (This Email) = []
-langRules (This Numeral) = Numeral.rules
-langRules (This Ordinal) = []
-langRules (This PhoneNumber) = []
-langRules (This Quantity) = []
-langRules (This RegexMatch) = []
-langRules (This Temperature) = []
-langRules (This Time) = []
-langRules (This TimeGrain) = TimeGrain.rules
-langRules (This Url) = []
-langRules (This Volume) = []
-langRules (This (CustomDimension dim)) = dimLangRules FI dim
+langRules :: Seal Dimension -> [Rule]
+langRules (Seal AmountOfMoney) = []
+langRules (Seal CreditCardNumber) = []
+langRules (Seal Distance) = []
+langRules (Seal Duration) = []
+langRules (Seal Email) = []
+langRules (Seal Numeral) = Numeral.rules
+langRules (Seal Ordinal) = []
+langRules (Seal PhoneNumber) = []
+langRules (Seal Quantity) = []
+langRules (Seal RegexMatch) = []
+langRules (Seal Temperature) = []
+langRules (Seal Time) = []
+langRules (Seal TimeGrain) = TimeGrain.rules
+langRules (Seal Url) = []
+langRules (Seal Volume) = []
+langRules (Seal (CustomDimension dim)) = dimLangRules FI dim

--- a/Duckling/Rules/FR.hs
+++ b/Duckling/Rules/FR.hs
@@ -29,27 +29,27 @@ import qualified Duckling.Time.FR.Rules as Time
 import qualified Duckling.TimeGrain.FR.Rules as TimeGrain
 import qualified Duckling.Volume.FR.Rules as Volume
 
-defaultRules :: Some Dimension -> [Rule]
+defaultRules :: Seal Dimension -> [Rule]
 defaultRules = langRules
 
-localeRules :: Region -> Some Dimension -> [Rule]
-localeRules region (This (CustomDimension dim)) = dimLocaleRules region dim
+localeRules :: Region -> Seal Dimension -> [Rule]
+localeRules region (Seal (CustomDimension dim)) = dimLocaleRules region dim
 localeRules _ _ = []
 
-langRules :: Some Dimension -> [Rule]
-langRules (This AmountOfMoney) = AmountOfMoney.rules
-langRules (This CreditCardNumber) = []
-langRules (This Distance) = Distance.rules
-langRules (This Duration) = Duration.rules
-langRules (This Email) = Email.rules
-langRules (This Numeral) = Numeral.rules
-langRules (This Ordinal) = Ordinal.rules
-langRules (This PhoneNumber) = []
-langRules (This Quantity) = Quantity.rules
-langRules (This RegexMatch) = []
-langRules (This Temperature) = Temperature.rules
-langRules (This Time) = Time.rules
-langRules (This TimeGrain) = TimeGrain.rules
-langRules (This Url) = []
-langRules (This Volume) = Volume.rules
-langRules (This (CustomDimension dim)) = dimLangRules FR dim
+langRules :: Seal Dimension -> [Rule]
+langRules (Seal AmountOfMoney) = AmountOfMoney.rules
+langRules (Seal CreditCardNumber) = []
+langRules (Seal Distance) = Distance.rules
+langRules (Seal Duration) = Duration.rules
+langRules (Seal Email) = Email.rules
+langRules (Seal Numeral) = Numeral.rules
+langRules (Seal Ordinal) = Ordinal.rules
+langRules (Seal PhoneNumber) = []
+langRules (Seal Quantity) = Quantity.rules
+langRules (Seal RegexMatch) = []
+langRules (Seal Temperature) = Temperature.rules
+langRules (Seal Time) = Time.rules
+langRules (Seal TimeGrain) = TimeGrain.rules
+langRules (Seal Url) = []
+langRules (Seal Volume) = Volume.rules
+langRules (Seal (CustomDimension dim)) = dimLangRules FR dim

--- a/Duckling/Rules/GA.hs
+++ b/Duckling/Rules/GA.hs
@@ -27,27 +27,27 @@ import qualified Duckling.Time.GA.Rules as Time
 import qualified Duckling.TimeGrain.GA.Rules as TimeGrain
 import qualified Duckling.Volume.GA.Rules as Volume
 
-defaultRules :: Some Dimension -> [Rule]
+defaultRules :: Seal Dimension -> [Rule]
 defaultRules = langRules
 
-localeRules :: Region -> Some Dimension -> [Rule]
-localeRules region (This (CustomDimension dim)) = dimLocaleRules region dim
+localeRules :: Region -> Seal Dimension -> [Rule]
+localeRules region (Seal (CustomDimension dim)) = dimLocaleRules region dim
 localeRules _ _ = []
 
-langRules :: Some Dimension -> [Rule]
-langRules (This AmountOfMoney) = AmountOfMoney.rules
-langRules (This CreditCardNumber) = []
-langRules (This Distance) = Distance.rules
-langRules (This Duration) = Duration.rules
-langRules (This Email) = []
-langRules (This Numeral) = Numeral.rules
-langRules (This Ordinal) = Ordinal.rules
-langRules (This PhoneNumber) = []
-langRules (This Quantity) = []
-langRules (This RegexMatch) = []
-langRules (This Temperature) = Temperature.rules
-langRules (This Time) = Time.rules
-langRules (This TimeGrain) = TimeGrain.rules
-langRules (This Url) = []
-langRules (This Volume) = Volume.rules
-langRules (This (CustomDimension dim)) = dimLangRules GA dim
+langRules :: Seal Dimension -> [Rule]
+langRules (Seal AmountOfMoney) = AmountOfMoney.rules
+langRules (Seal CreditCardNumber) = []
+langRules (Seal Distance) = Distance.rules
+langRules (Seal Duration) = Duration.rules
+langRules (Seal Email) = []
+langRules (Seal Numeral) = Numeral.rules
+langRules (Seal Ordinal) = Ordinal.rules
+langRules (Seal PhoneNumber) = []
+langRules (Seal Quantity) = []
+langRules (Seal RegexMatch) = []
+langRules (Seal Temperature) = Temperature.rules
+langRules (Seal Time) = Time.rules
+langRules (Seal TimeGrain) = TimeGrain.rules
+langRules (Seal Url) = []
+langRules (Seal Volume) = Volume.rules
+langRules (Seal (CustomDimension dim)) = dimLangRules GA dim

--- a/Duckling/Rules/HE.hs
+++ b/Duckling/Rules/HE.hs
@@ -24,27 +24,27 @@ import qualified Duckling.Ordinal.HE.Rules as Ordinal
 import qualified Duckling.TimeGrain.HE.Rules as TimeGrain
 import qualified Duckling.Time.HE.Rules as Time
 
-defaultRules :: Some Dimension -> [Rule]
+defaultRules :: Seal Dimension -> [Rule]
 defaultRules = langRules
 
-localeRules :: Region -> Some Dimension -> [Rule]
-localeRules region (This (CustomDimension dim)) = dimLocaleRules region dim
+localeRules :: Region -> Seal Dimension -> [Rule]
+localeRules region (Seal (CustomDimension dim)) = dimLocaleRules region dim
 localeRules _ _ = []
 
-langRules :: Some Dimension -> [Rule]
-langRules (This AmountOfMoney) = AmountOfMoney.rules
-langRules (This CreditCardNumber) = []
-langRules (This Distance) = []
-langRules (This Duration) = Duration.rules
-langRules (This Email) = []
-langRules (This Numeral) = Numeral.rules
-langRules (This Ordinal) = Ordinal.rules
-langRules (This PhoneNumber) = []
-langRules (This Quantity) = []
-langRules (This RegexMatch) = []
-langRules (This Temperature) = []
-langRules (This Time) = Time.rules
-langRules (This TimeGrain) = TimeGrain.rules
-langRules (This Url) = []
-langRules (This Volume) = []
-langRules (This (CustomDimension dim)) = dimLangRules HE dim
+langRules :: Seal Dimension -> [Rule]
+langRules (Seal AmountOfMoney) = AmountOfMoney.rules
+langRules (Seal CreditCardNumber) = []
+langRules (Seal Distance) = []
+langRules (Seal Duration) = Duration.rules
+langRules (Seal Email) = []
+langRules (Seal Numeral) = Numeral.rules
+langRules (Seal Ordinal) = Ordinal.rules
+langRules (Seal PhoneNumber) = []
+langRules (Seal Quantity) = []
+langRules (Seal RegexMatch) = []
+langRules (Seal Temperature) = []
+langRules (Seal Time) = Time.rules
+langRules (Seal TimeGrain) = TimeGrain.rules
+langRules (Seal Url) = []
+langRules (Seal Volume) = []
+langRules (Seal (CustomDimension dim)) = dimLangRules HE dim

--- a/Duckling/Rules/HI.hs
+++ b/Duckling/Rules/HI.hs
@@ -22,27 +22,27 @@ import qualified Duckling.Duration.HI.Rules as Duration
 import qualified Duckling.TimeGrain.HI.Rules as TimeGrain
 import qualified Duckling.Temperature.HI.Rules as Temperature
 
-defaultRules :: Some Dimension -> [Rule]
+defaultRules :: Seal Dimension -> [Rule]
 defaultRules = langRules
 
-localeRules :: Region -> Some Dimension -> [Rule]
-localeRules region (This (CustomDimension dim)) = dimLocaleRules region dim
+localeRules :: Region -> Seal Dimension -> [Rule]
+localeRules region (Seal (CustomDimension dim)) = dimLocaleRules region dim
 localeRules _ _ = []
 
-langRules :: Some Dimension -> [Rule]
-langRules (This AmountOfMoney) = []
-langRules (This CreditCardNumber) = []
-langRules (This Distance) = []
-langRules (This Duration) = Duration.rules
-langRules (This Numeral) = Numeral.rules
-langRules (This Email) = []
-langRules (This Ordinal) = Ordinal.rules
-langRules (This PhoneNumber) = []
-langRules (This Quantity) = []
-langRules (This RegexMatch) = []
-langRules (This Temperature) = Temperature.rules
-langRules (This Time) = []
-langRules (This TimeGrain) = TimeGrain.rules
-langRules (This Url) = []
-langRules (This Volume) = []
-langRules (This (CustomDimension dim)) = dimLangRules HI dim
+langRules :: Seal Dimension -> [Rule]
+langRules (Seal AmountOfMoney) = []
+langRules (Seal CreditCardNumber) = []
+langRules (Seal Distance) = []
+langRules (Seal Duration) = Duration.rules
+langRules (Seal Numeral) = Numeral.rules
+langRules (Seal Email) = []
+langRules (Seal Ordinal) = Ordinal.rules
+langRules (Seal PhoneNumber) = []
+langRules (Seal Quantity) = []
+langRules (Seal RegexMatch) = []
+langRules (Seal Temperature) = Temperature.rules
+langRules (Seal Time) = []
+langRules (Seal TimeGrain) = TimeGrain.rules
+langRules (Seal Url) = []
+langRules (Seal Volume) = []
+langRules (Seal (CustomDimension dim)) = dimLangRules HI dim

--- a/Duckling/Rules/HR.hs
+++ b/Duckling/Rules/HR.hs
@@ -29,27 +29,27 @@ import qualified Duckling.TimeGrain.HR.Rules as TimeGrain
 import qualified Duckling.Volume.HR.Rules as Volume
 
 
-defaultRules :: Some Dimension -> [Rule]
+defaultRules :: Seal Dimension -> [Rule]
 defaultRules = langRules
 
-localeRules :: Region -> Some Dimension -> [Rule]
-localeRules region (This (CustomDimension dim)) = dimLocaleRules region dim
+localeRules :: Region -> Seal Dimension -> [Rule]
+localeRules region (Seal (CustomDimension dim)) = dimLocaleRules region dim
 localeRules _ _ = []
 
-langRules :: Some Dimension -> [Rule]
-langRules (This AmountOfMoney) = AmountOfMoney.rules
-langRules (This CreditCardNumber) = []
-langRules (This Distance) = Distance.rules
-langRules (This Duration) = Duration.rules
-langRules (This Email) = []
-langRules (This Numeral) = Numeral.rules
-langRules (This Ordinal) = Ordinal.rules
-langRules (This PhoneNumber) = []
-langRules (This Quantity) = Quantity.rules
-langRules (This RegexMatch) = []
-langRules (This Temperature) = Temperature.rules
-langRules (This Time) = Time.rules
-langRules (This TimeGrain) = TimeGrain.rules
-langRules (This Url) = []
-langRules (This Volume) = Volume.rules
-langRules (This (CustomDimension dim)) = dimLangRules HR dim
+langRules :: Seal Dimension -> [Rule]
+langRules (Seal AmountOfMoney) = AmountOfMoney.rules
+langRules (Seal CreditCardNumber) = []
+langRules (Seal Distance) = Distance.rules
+langRules (Seal Duration) = Duration.rules
+langRules (Seal Email) = []
+langRules (Seal Numeral) = Numeral.rules
+langRules (Seal Ordinal) = Ordinal.rules
+langRules (Seal PhoneNumber) = []
+langRules (Seal Quantity) = Quantity.rules
+langRules (Seal RegexMatch) = []
+langRules (Seal Temperature) = Temperature.rules
+langRules (Seal Time) = Time.rules
+langRules (Seal TimeGrain) = TimeGrain.rules
+langRules (Seal Url) = []
+langRules (Seal Volume) = Volume.rules
+langRules (Seal (CustomDimension dim)) = dimLangRules HR dim

--- a/Duckling/Rules/HU.hs
+++ b/Duckling/Rules/HU.hs
@@ -23,27 +23,27 @@ import qualified Duckling.Ordinal.HU.Rules as Ordinal
 import qualified Duckling.Time.HU.Rules as Time
 import qualified Duckling.TimeGrain.HU.Rules as TimeGrain
 
-defaultRules :: Some Dimension -> [Rule]
+defaultRules :: Seal Dimension -> [Rule]
 defaultRules = langRules
 
-localeRules :: Region -> Some Dimension -> [Rule]
-localeRules region (This (CustomDimension dim)) = dimLocaleRules region dim
+localeRules :: Region -> Seal Dimension -> [Rule]
+localeRules region (Seal (CustomDimension dim)) = dimLocaleRules region dim
 localeRules _ _ = []
 
-langRules :: Some Dimension -> [Rule]
-langRules (This AmountOfMoney) = []
-langRules (This CreditCardNumber) = []
-langRules (This Distance) = []
-langRules (This Duration) = Duration.rules
-langRules (This Email) = []
-langRules (This Numeral) = Numeral.rules
-langRules (This Ordinal) = Ordinal.rules
-langRules (This PhoneNumber) = []
-langRules (This Quantity) = []
-langRules (This RegexMatch) = []
-langRules (This Temperature) = []
-langRules (This Time) = Time.rules
-langRules (This TimeGrain) = TimeGrain.rules
-langRules (This Url) = []
-langRules (This Volume) = []
-langRules (This (CustomDimension dim)) = dimLangRules HU dim
+langRules :: Seal Dimension -> [Rule]
+langRules (Seal AmountOfMoney) = []
+langRules (Seal CreditCardNumber) = []
+langRules (Seal Distance) = []
+langRules (Seal Duration) = Duration.rules
+langRules (Seal Email) = []
+langRules (Seal Numeral) = Numeral.rules
+langRules (Seal Ordinal) = Ordinal.rules
+langRules (Seal PhoneNumber) = []
+langRules (Seal Quantity) = []
+langRules (Seal RegexMatch) = []
+langRules (Seal Temperature) = []
+langRules (Seal Time) = Time.rules
+langRules (Seal TimeGrain) = TimeGrain.rules
+langRules (Seal Url) = []
+langRules (Seal Volume) = []
+langRules (Seal (CustomDimension dim)) = dimLangRules HU dim

--- a/Duckling/Rules/ID.hs
+++ b/Duckling/Rules/ID.hs
@@ -21,27 +21,27 @@ import qualified Duckling.AmountOfMoney.ID.Rules as AmountOfMoney
 import qualified Duckling.Numeral.ID.Rules as Numeral
 import qualified Duckling.Ordinal.ID.Rules as Ordinal
 
-defaultRules :: Some Dimension -> [Rule]
+defaultRules :: Seal Dimension -> [Rule]
 defaultRules = langRules
 
-localeRules :: Region -> Some Dimension -> [Rule]
-localeRules region (This (CustomDimension dim)) = dimLocaleRules region dim
+localeRules :: Region -> Seal Dimension -> [Rule]
+localeRules region (Seal (CustomDimension dim)) = dimLocaleRules region dim
 localeRules _ _ = []
 
-langRules :: Some Dimension -> [Rule]
-langRules (This AmountOfMoney) = AmountOfMoney.rules
-langRules (This CreditCardNumber) = []
-langRules (This Distance) = []
-langRules (This Duration) = []
-langRules (This Email) = []
-langRules (This Numeral) = Numeral.rules
-langRules (This Ordinal) = Ordinal.rules
-langRules (This PhoneNumber) = []
-langRules (This Quantity) = []
-langRules (This RegexMatch) = []
-langRules (This Temperature) = []
-langRules (This Time) = []
-langRules (This TimeGrain) = []
-langRules (This Url) = []
-langRules (This Volume) = []
-langRules (This (CustomDimension dim)) = dimLangRules ID dim
+langRules :: Seal Dimension -> [Rule]
+langRules (Seal AmountOfMoney) = AmountOfMoney.rules
+langRules (Seal CreditCardNumber) = []
+langRules (Seal Distance) = []
+langRules (Seal Duration) = []
+langRules (Seal Email) = []
+langRules (Seal Numeral) = Numeral.rules
+langRules (Seal Ordinal) = Ordinal.rules
+langRules (Seal PhoneNumber) = []
+langRules (Seal Quantity) = []
+langRules (Seal RegexMatch) = []
+langRules (Seal Temperature) = []
+langRules (Seal Time) = []
+langRules (Seal TimeGrain) = []
+langRules (Seal Url) = []
+langRules (Seal Volume) = []
+langRules (Seal (CustomDimension dim)) = dimLangRules ID dim

--- a/Duckling/Rules/IS.hs
+++ b/Duckling/Rules/IS.hs
@@ -19,27 +19,27 @@ import Duckling.Types
 import qualified Duckling.Email.IS.Rules as Email
 import qualified Duckling.Numeral.IS.Rules as Numeral
 
-defaultRules :: Some Dimension -> [Rule]
+defaultRules :: Seal Dimension -> [Rule]
 defaultRules = langRules
 
-localeRules :: Region -> Some Dimension -> [Rule]
-localeRules region (This (CustomDimension dim)) = dimLocaleRules region dim
+localeRules :: Region -> Seal Dimension -> [Rule]
+localeRules region (Seal (CustomDimension dim)) = dimLocaleRules region dim
 localeRules _ _ = []
 
-langRules :: Some Dimension -> [Rule]
-langRules (This CreditCardNumber) = []
-langRules (This Distance) = []
-langRules (This Duration) = []
-langRules (This Numeral) = Numeral.rules
-langRules (This Email) = Email.rules
-langRules (This AmountOfMoney) = []
-langRules (This Ordinal) = []
-langRules (This PhoneNumber) = []
-langRules (This Quantity) = []
-langRules (This RegexMatch) = []
-langRules (This Temperature) = []
-langRules (This Time) = []
-langRules (This TimeGrain) = []
-langRules (This Url) = []
-langRules (This Volume) = []
-langRules (This (CustomDimension dim)) = dimLangRules IS dim
+langRules :: Seal Dimension -> [Rule]
+langRules (Seal CreditCardNumber) = []
+langRules (Seal Distance) = []
+langRules (Seal Duration) = []
+langRules (Seal Numeral) = Numeral.rules
+langRules (Seal Email) = Email.rules
+langRules (Seal AmountOfMoney) = []
+langRules (Seal Ordinal) = []
+langRules (Seal PhoneNumber) = []
+langRules (Seal Quantity) = []
+langRules (Seal RegexMatch) = []
+langRules (Seal Temperature) = []
+langRules (Seal Time) = []
+langRules (Seal TimeGrain) = []
+langRules (Seal Url) = []
+langRules (Seal Volume) = []
+langRules (Seal (CustomDimension dim)) = dimLangRules IS dim

--- a/Duckling/Rules/IT.hs
+++ b/Duckling/Rules/IT.hs
@@ -28,27 +28,27 @@ import qualified Duckling.Time.IT.Rules as Time
 import qualified Duckling.TimeGrain.IT.Rules as TimeGrain
 import qualified Duckling.Volume.IT.Rules as Volume
 
-defaultRules :: Some Dimension -> [Rule]
+defaultRules :: Seal Dimension -> [Rule]
 defaultRules = langRules
 
-localeRules :: Region -> Some Dimension -> [Rule]
-localeRules region (This (CustomDimension dim)) = dimLocaleRules region dim
+localeRules :: Region -> Seal Dimension -> [Rule]
+localeRules region (Seal (CustomDimension dim)) = dimLocaleRules region dim
 localeRules _ _ = []
 
-langRules :: Some Dimension -> [Rule]
-langRules (This AmountOfMoney) = AmountOfMoney.rules
-langRules (This CreditCardNumber) = []
-langRules (This Distance) = Distance.rules
-langRules (This Duration) = Duration.rules
-langRules (This Email) = Email.rules
-langRules (This Numeral) = Numeral.rules
-langRules (This Ordinal) = Ordinal.rules
-langRules (This PhoneNumber) = []
-langRules (This Quantity) = []
-langRules (This RegexMatch) = []
-langRules (This Temperature) = Temperature.rules
-langRules (This Time) = Time.rules
-langRules (This TimeGrain) = TimeGrain.rules
-langRules (This Url) = []
-langRules (This Volume) = Volume.rules
-langRules (This (CustomDimension dim)) = dimLangRules IT dim
+langRules :: Seal Dimension -> [Rule]
+langRules (Seal AmountOfMoney) = AmountOfMoney.rules
+langRules (Seal CreditCardNumber) = []
+langRules (Seal Distance) = Distance.rules
+langRules (Seal Duration) = Duration.rules
+langRules (Seal Email) = Email.rules
+langRules (Seal Numeral) = Numeral.rules
+langRules (Seal Ordinal) = Ordinal.rules
+langRules (Seal PhoneNumber) = []
+langRules (Seal Quantity) = []
+langRules (Seal RegexMatch) = []
+langRules (Seal Temperature) = Temperature.rules
+langRules (Seal Time) = Time.rules
+langRules (Seal TimeGrain) = TimeGrain.rules
+langRules (Seal Url) = []
+langRules (Seal Volume) = Volume.rules
+langRules (Seal (CustomDimension dim)) = dimLangRules IT dim

--- a/Duckling/Rules/JA.hs
+++ b/Duckling/Rules/JA.hs
@@ -22,27 +22,27 @@ import qualified Duckling.Ordinal.JA.Rules as Ordinal
 import qualified Duckling.Temperature.JA.Rules as Temperature
 import qualified Duckling.TimeGrain.JA.Rules as TimeGrain
 
-defaultRules :: Some Dimension -> [Rule]
+defaultRules :: Seal Dimension -> [Rule]
 defaultRules = langRules
 
-localeRules :: Region -> Some Dimension -> [Rule]
-localeRules region (This (CustomDimension dim)) = dimLocaleRules region dim
+localeRules :: Region -> Seal Dimension -> [Rule]
+localeRules region (Seal (CustomDimension dim)) = dimLocaleRules region dim
 localeRules _ _ = []
 
-langRules :: Some Dimension -> [Rule]
-langRules (This AmountOfMoney) = []
-langRules (This CreditCardNumber) = []
-langRules (This Distance) = []
-langRules (This Duration) = []
-langRules (This Email) = []
-langRules (This Numeral) = Numeral.rules
-langRules (This Ordinal) = Ordinal.rules
-langRules (This PhoneNumber) = []
-langRules (This Quantity) = []
-langRules (This RegexMatch) = []
-langRules (This Temperature) = Temperature.rules
-langRules (This Time) = []
-langRules (This TimeGrain) = TimeGrain.rules
-langRules (This Url) = []
-langRules (This Volume) = []
-langRules (This (CustomDimension dim)) = dimLangRules JA dim
+langRules :: Seal Dimension -> [Rule]
+langRules (Seal AmountOfMoney) = []
+langRules (Seal CreditCardNumber) = []
+langRules (Seal Distance) = []
+langRules (Seal Duration) = []
+langRules (Seal Email) = []
+langRules (Seal Numeral) = Numeral.rules
+langRules (Seal Ordinal) = Ordinal.rules
+langRules (Seal PhoneNumber) = []
+langRules (Seal Quantity) = []
+langRules (Seal RegexMatch) = []
+langRules (Seal Temperature) = Temperature.rules
+langRules (Seal Time) = []
+langRules (Seal TimeGrain) = TimeGrain.rules
+langRules (Seal Url) = []
+langRules (Seal Volume) = []
+langRules (Seal (CustomDimension dim)) = dimLangRules JA dim

--- a/Duckling/Rules/KA.hs
+++ b/Duckling/Rules/KA.hs
@@ -24,27 +24,27 @@ import qualified Duckling.TimeGrain.KA.Rules as TimeGrain
 import qualified Duckling.Ordinal.KA.Rules as Ordinal
 import qualified Duckling.Duration.KA.Rules as Duration
 
-defaultRules :: Some Dimension -> [Rule]
+defaultRules :: Seal Dimension -> [Rule]
 defaultRules = langRules
 
-localeRules :: Region -> Some Dimension -> [Rule]
-localeRules region (This (CustomDimension dim)) = dimLocaleRules region dim
+localeRules :: Region -> Seal Dimension -> [Rule]
+localeRules region (Seal (CustomDimension dim)) = dimLocaleRules region dim
 localeRules _ _ = []
 
-langRules :: Some Dimension -> [Rule]
-langRules (This AmountOfMoney) = AmountOfMoney.rules
-langRules (This CreditCardNumber) = []
-langRules (This Distance) = []
-langRules (This Duration) = Duration.rules
-langRules (This Email) = []
-langRules (This Numeral) = Numeral.rules
-langRules (This Ordinal) = Ordinal.rules
-langRules (This PhoneNumber) = []
-langRules (This Quantity) = []
-langRules (This RegexMatch) = []
-langRules (This Temperature) = []
-langRules (This Time) = Time.rules
-langRules (This TimeGrain) = TimeGrain.rules
-langRules (This Url) = []
-langRules (This Volume) = []
-langRules (This (CustomDimension dim)) = dimLangRules KA dim
+langRules :: Seal Dimension -> [Rule]
+langRules (Seal AmountOfMoney) = AmountOfMoney.rules
+langRules (Seal CreditCardNumber) = []
+langRules (Seal Distance) = []
+langRules (Seal Duration) = Duration.rules
+langRules (Seal Email) = []
+langRules (Seal Numeral) = Numeral.rules
+langRules (Seal Ordinal) = Ordinal.rules
+langRules (Seal PhoneNumber) = []
+langRules (Seal Quantity) = []
+langRules (Seal RegexMatch) = []
+langRules (Seal Temperature) = []
+langRules (Seal Time) = Time.rules
+langRules (Seal TimeGrain) = TimeGrain.rules
+langRules (Seal Url) = []
+langRules (Seal Volume) = []
+langRules (Seal (CustomDimension dim)) = dimLangRules KA dim

--- a/Duckling/Rules/KM.hs
+++ b/Duckling/Rules/KM.hs
@@ -24,27 +24,27 @@ import qualified Duckling.Quantity.KM.Rules as Quantity
 import qualified Duckling.Temperature.KM.Rules as Temperature
 import qualified Duckling.Volume.KM.Rules as Volume
 
-defaultRules :: Some Dimension -> [Rule]
+defaultRules :: Seal Dimension -> [Rule]
 defaultRules = langRules
 
-localeRules :: Region -> Some Dimension -> [Rule]
-localeRules region (This (CustomDimension dim)) = dimLocaleRules region dim
+localeRules :: Region -> Seal Dimension -> [Rule]
+localeRules region (Seal (CustomDimension dim)) = dimLocaleRules region dim
 localeRules _ _ = []
 
-langRules :: Some Dimension -> [Rule]
-langRules (This AmountOfMoney) = []
-langRules (This CreditCardNumber) = []
-langRules (This Distance) = Distance.rules
-langRules (This Duration) = []
-langRules (This Email) = []
-langRules (This Numeral) = Numeral.rules
-langRules (This Ordinal) = Ordinal.rules
-langRules (This PhoneNumber) = []
-langRules (This Quantity) = Quantity.rules
-langRules (This RegexMatch) = []
-langRules (This Temperature) = Temperature.rules
-langRules (This Time) = []
-langRules (This TimeGrain) = []
-langRules (This Url) = []
-langRules (This Volume) = Volume.rules
-langRules (This (CustomDimension dim)) = dimLangRules KM dim
+langRules :: Seal Dimension -> [Rule]
+langRules (Seal AmountOfMoney) = []
+langRules (Seal CreditCardNumber) = []
+langRules (Seal Distance) = Distance.rules
+langRules (Seal Duration) = []
+langRules (Seal Email) = []
+langRules (Seal Numeral) = Numeral.rules
+langRules (Seal Ordinal) = Ordinal.rules
+langRules (Seal PhoneNumber) = []
+langRules (Seal Quantity) = Quantity.rules
+langRules (Seal RegexMatch) = []
+langRules (Seal Temperature) = Temperature.rules
+langRules (Seal Time) = []
+langRules (Seal TimeGrain) = []
+langRules (Seal Url) = []
+langRules (Seal Volume) = Volume.rules
+langRules (Seal (CustomDimension dim)) = dimLangRules KM dim

--- a/Duckling/Rules/KN.hs
+++ b/Duckling/Rules/KN.hs
@@ -18,27 +18,27 @@ import Duckling.Locale
 import Duckling.Types
 import qualified Duckling.Numeral.KN.Rules as Numeral
 
-defaultRules :: Some Dimension -> [Rule]
+defaultRules :: Seal Dimension -> [Rule]
 defaultRules = langRules
 
-localeRules :: Region -> Some Dimension -> [Rule]
-localeRules region (This (CustomDimension dim)) = dimLocaleRules region dim
+localeRules :: Region -> Seal Dimension -> [Rule]
+localeRules region (Seal (CustomDimension dim)) = dimLocaleRules region dim
 localeRules _ _ = []
 
-langRules :: Some Dimension -> [Rule]
-langRules (This AmountOfMoney) = []
-langRules (This CreditCardNumber) = []
-langRules (This Distance) = []
-langRules (This Duration) = []
-langRules (This Numeral) = Numeral.rules
-langRules (This Email) = []
-langRules (This Ordinal) = []
-langRules (This PhoneNumber) = []
-langRules (This Quantity) = []
-langRules (This RegexMatch) = []
-langRules (This Temperature) = []
-langRules (This Time) = []
-langRules (This TimeGrain) = []
-langRules (This Url) = []
-langRules (This Volume) = []
-langRules (This (CustomDimension dim)) = dimLangRules KN dim
+langRules :: Seal Dimension -> [Rule]
+langRules (Seal AmountOfMoney) = []
+langRules (Seal CreditCardNumber) = []
+langRules (Seal Distance) = []
+langRules (Seal Duration) = []
+langRules (Seal Numeral) = Numeral.rules
+langRules (Seal Email) = []
+langRules (Seal Ordinal) = []
+langRules (Seal PhoneNumber) = []
+langRules (Seal Quantity) = []
+langRules (Seal RegexMatch) = []
+langRules (Seal Temperature) = []
+langRules (Seal Time) = []
+langRules (Seal TimeGrain) = []
+langRules (Seal Url) = []
+langRules (Seal Volume) = []
+langRules (Seal (CustomDimension dim)) = dimLangRules KN dim

--- a/Duckling/Rules/KO.hs
+++ b/Duckling/Rules/KO.hs
@@ -28,27 +28,27 @@ import qualified Duckling.Time.KO.Rules as Time
 import qualified Duckling.TimeGrain.KO.Rules as TimeGrain
 import qualified Duckling.Volume.KO.Rules as Volume
 
-defaultRules :: Some Dimension -> [Rule]
+defaultRules :: Seal Dimension -> [Rule]
 defaultRules = langRules
 
-localeRules :: Region -> Some Dimension -> [Rule]
-localeRules region (This (CustomDimension dim)) = dimLocaleRules region dim
+localeRules :: Region -> Seal Dimension -> [Rule]
+localeRules region (Seal (CustomDimension dim)) = dimLocaleRules region dim
 localeRules _ _ = []
 
-langRules :: Some Dimension -> [Rule]
-langRules (This AmountOfMoney) = AmountOfMoney.rules
-langRules (This CreditCardNumber) = []
-langRules (This Distance) = Distance.rules
-langRules (This Duration) = Duration.rules
-langRules (This Email) = []
-langRules (This Numeral) = Numeral.rules
-langRules (This Ordinal) = Ordinal.rules
-langRules (This PhoneNumber) = []
-langRules (This Quantity) = Quantity.rules
-langRules (This RegexMatch) = []
-langRules (This Temperature) = Temperature.rules
-langRules (This Time) = Time.rules
-langRules (This TimeGrain) = TimeGrain.rules
-langRules (This Url) = []
-langRules (This Volume) = Volume.rules
-langRules (This (CustomDimension dim)) = dimLangRules KO dim
+langRules :: Seal Dimension -> [Rule]
+langRules (Seal AmountOfMoney) = AmountOfMoney.rules
+langRules (Seal CreditCardNumber) = []
+langRules (Seal Distance) = Distance.rules
+langRules (Seal Duration) = Duration.rules
+langRules (Seal Email) = []
+langRules (Seal Numeral) = Numeral.rules
+langRules (Seal Ordinal) = Ordinal.rules
+langRules (Seal PhoneNumber) = []
+langRules (Seal Quantity) = Quantity.rules
+langRules (Seal RegexMatch) = []
+langRules (Seal Temperature) = Temperature.rules
+langRules (Seal Time) = Time.rules
+langRules (Seal TimeGrain) = TimeGrain.rules
+langRules (Seal Url) = []
+langRules (Seal Volume) = Volume.rules
+langRules (Seal (CustomDimension dim)) = dimLangRules KO dim

--- a/Duckling/Rules/LO.hs
+++ b/Duckling/Rules/LO.hs
@@ -19,27 +19,27 @@ import Duckling.Locale
 import Duckling.Types
 import qualified Duckling.Numeral.LO.Rules as Numeral
 
-defaultRules :: Some Dimension -> [Rule]
+defaultRules :: Seal Dimension -> [Rule]
 defaultRules = langRules
 
-localeRules :: Region -> Some Dimension -> [Rule]
-localeRules region (This (CustomDimension dim)) = dimLocaleRules region dim
+localeRules :: Region -> Seal Dimension -> [Rule]
+localeRules region (Seal (CustomDimension dim)) = dimLocaleRules region dim
 localeRules _ _ = []
 
-langRules :: Some Dimension -> [Rule]
-langRules (This AmountOfMoney) = []
-langRules (This CreditCardNumber) = []
-langRules (This Distance) = []
-langRules (This Duration) = []
-langRules (This Email) = []
-langRules (This Numeral) = Numeral.rules
-langRules (This Ordinal) = []
-langRules (This PhoneNumber) = []
-langRules (This Quantity) = []
-langRules (This RegexMatch) = []
-langRules (This Temperature) = []
-langRules (This Time) = []
-langRules (This TimeGrain) = []
-langRules (This Url) = []
-langRules (This Volume) = []
-langRules (This (CustomDimension dim)) = dimLangRules LO dim
+langRules :: Seal Dimension -> [Rule]
+langRules (Seal AmountOfMoney) = []
+langRules (Seal CreditCardNumber) = []
+langRules (Seal Distance) = []
+langRules (Seal Duration) = []
+langRules (Seal Email) = []
+langRules (Seal Numeral) = Numeral.rules
+langRules (Seal Ordinal) = []
+langRules (Seal PhoneNumber) = []
+langRules (Seal Quantity) = []
+langRules (Seal RegexMatch) = []
+langRules (Seal Temperature) = []
+langRules (Seal Time) = []
+langRules (Seal TimeGrain) = []
+langRules (Seal Url) = []
+langRules (Seal Volume) = []
+langRules (Seal (CustomDimension dim)) = dimLangRules LO dim

--- a/Duckling/Rules/ML.hs
+++ b/Duckling/Rules/ML.hs
@@ -20,27 +20,27 @@ import Duckling.Types
 import qualified Duckling.Numeral.ML.Rules as Numeral
 import qualified Duckling.Ordinal.ML.Rules as Ordinal
 
-defaultRules :: Some Dimension -> [Rule]
+defaultRules :: Seal Dimension -> [Rule]
 defaultRules = langRules
 
-localeRules :: Region -> Some Dimension -> [Rule]
-localeRules region (This (CustomDimension dim)) = dimLocaleRules region dim
+localeRules :: Region -> Seal Dimension -> [Rule]
+localeRules region (Seal (CustomDimension dim)) = dimLocaleRules region dim
 localeRules _ _ = []
 
-langRules :: Some Dimension -> [Rule]
-langRules (This AmountOfMoney) = []
-langRules (This CreditCardNumber) = []
-langRules (This Distance) = []
-langRules (This Duration) = []
-langRules (This Email) = []
-langRules (This Numeral) = Numeral.rules
-langRules (This Ordinal) = Ordinal.rules
-langRules (This PhoneNumber) = []
-langRules (This Quantity) = []
-langRules (This RegexMatch) = []
-langRules (This Temperature) = []
-langRules (This Time) = []
-langRules (This TimeGrain) = []
-langRules (This Url) = []
-langRules (This Volume) = []
-langRules (This (CustomDimension dim)) = dimLangRules ML dim
+langRules :: Seal Dimension -> [Rule]
+langRules (Seal AmountOfMoney) = []
+langRules (Seal CreditCardNumber) = []
+langRules (Seal Distance) = []
+langRules (Seal Duration) = []
+langRules (Seal Email) = []
+langRules (Seal Numeral) = Numeral.rules
+langRules (Seal Ordinal) = Ordinal.rules
+langRules (Seal PhoneNumber) = []
+langRules (Seal Quantity) = []
+langRules (Seal RegexMatch) = []
+langRules (Seal Temperature) = []
+langRules (Seal Time) = []
+langRules (Seal TimeGrain) = []
+langRules (Seal Url) = []
+langRules (Seal Volume) = []
+langRules (Seal (CustomDimension dim)) = dimLangRules ML dim

--- a/Duckling/Rules/MN.hs
+++ b/Duckling/Rules/MN.hs
@@ -27,27 +27,27 @@ import qualified Duckling.TimeGrain.MN.Rules as TimeGrain
 import qualified Duckling.Volume.MN.Rules as Volume
 import qualified Duckling.Temperature.MN.Rules as Temperature
 
-defaultRules :: Some Dimension -> [Rule]
+defaultRules :: Seal Dimension -> [Rule]
 defaultRules = langRules
 
-localeRules :: Region -> Some Dimension -> [Rule]
-localeRules region (This (CustomDimension dim)) = dimLocaleRules region dim
+localeRules :: Region -> Seal Dimension -> [Rule]
+localeRules region (Seal (CustomDimension dim)) = dimLocaleRules region dim
 localeRules _ _ = []
 
-langRules :: Some Dimension -> [Rule]
-langRules (This AmountOfMoney) = AmountOfMoney.rules
-langRules (This CreditCardNumber) = []
-langRules (This Distance) = Distance.rules
-langRules (This Duration) = Duration.rules
-langRules (This Email) = []
-langRules (This Numeral) = Numeral.rules
-langRules (This Ordinal) = Ordinal.rules
-langRules (This PhoneNumber) = []
-langRules (This Quantity) = Quantity.rules
-langRules (This RegexMatch) = []
-langRules (This Temperature) = Temperature.rules
-langRules (This Time) = []
-langRules (This TimeGrain) = TimeGrain.rules
-langRules (This Url) = []
-langRules (This Volume) = Volume.rules
-langRules (This (CustomDimension dim)) = dimLangRules MN dim
+langRules :: Seal Dimension -> [Rule]
+langRules (Seal AmountOfMoney) = AmountOfMoney.rules
+langRules (Seal CreditCardNumber) = []
+langRules (Seal Distance) = Distance.rules
+langRules (Seal Duration) = Duration.rules
+langRules (Seal Email) = []
+langRules (Seal Numeral) = Numeral.rules
+langRules (Seal Ordinal) = Ordinal.rules
+langRules (Seal PhoneNumber) = []
+langRules (Seal Quantity) = Quantity.rules
+langRules (Seal RegexMatch) = []
+langRules (Seal Temperature) = Temperature.rules
+langRules (Seal Time) = []
+langRules (Seal TimeGrain) = TimeGrain.rules
+langRules (Seal Url) = []
+langRules (Seal Volume) = Volume.rules
+langRules (Seal (CustomDimension dim)) = dimLangRules MN dim

--- a/Duckling/Rules/MY.hs
+++ b/Duckling/Rules/MY.hs
@@ -19,27 +19,27 @@ import Duckling.Locale
 import Duckling.Types
 import qualified Duckling.Numeral.MY.Rules as Numeral
 
-defaultRules :: Some Dimension -> [Rule]
+defaultRules :: Seal Dimension -> [Rule]
 defaultRules = langRules
 
-localeRules :: Region -> Some Dimension -> [Rule]
-localeRules region (This (CustomDimension dim)) = dimLocaleRules region dim
+localeRules :: Region -> Seal Dimension -> [Rule]
+localeRules region (Seal (CustomDimension dim)) = dimLocaleRules region dim
 localeRules _ _ = []
 
-langRules :: Some Dimension -> [Rule]
-langRules (This AmountOfMoney) = []
-langRules (This CreditCardNumber) = []
-langRules (This Distance) = []
-langRules (This Duration) = []
-langRules (This Email) = []
-langRules (This Numeral) = Numeral.rules
-langRules (This Ordinal) = []
-langRules (This PhoneNumber) = []
-langRules (This Quantity) = []
-langRules (This RegexMatch) = []
-langRules (This Temperature) = []
-langRules (This Time) = []
-langRules (This TimeGrain) = []
-langRules (This Url) = []
-langRules (This Volume) = []
-langRules (This (CustomDimension dim)) = dimLangRules MY dim
+langRules :: Seal Dimension -> [Rule]
+langRules (Seal AmountOfMoney) = []
+langRules (Seal CreditCardNumber) = []
+langRules (Seal Distance) = []
+langRules (Seal Duration) = []
+langRules (Seal Email) = []
+langRules (Seal Numeral) = Numeral.rules
+langRules (Seal Ordinal) = []
+langRules (Seal PhoneNumber) = []
+langRules (Seal Quantity) = []
+langRules (Seal RegexMatch) = []
+langRules (Seal Temperature) = []
+langRules (Seal Time) = []
+langRules (Seal TimeGrain) = []
+langRules (Seal Url) = []
+langRules (Seal Volume) = []
+langRules (Seal (CustomDimension dim)) = dimLangRules MY dim

--- a/Duckling/Rules/NB.hs
+++ b/Duckling/Rules/NB.hs
@@ -24,27 +24,27 @@ import qualified Duckling.Ordinal.NB.Rules as Ordinal
 import qualified Duckling.Time.NB.Rules as Time
 import qualified Duckling.TimeGrain.NB.Rules as TimeGrain
 
-defaultRules :: Some Dimension -> [Rule]
+defaultRules :: Seal Dimension -> [Rule]
 defaultRules = langRules
 
-localeRules :: Region -> Some Dimension -> [Rule]
-localeRules region (This (CustomDimension dim)) = dimLocaleRules region dim
+localeRules :: Region -> Seal Dimension -> [Rule]
+localeRules region (Seal (CustomDimension dim)) = dimLocaleRules region dim
 localeRules _ _ = []
 
-langRules :: Some Dimension -> [Rule]
-langRules (This AmountOfMoney) = AmountOfMoney.rules
-langRules (This CreditCardNumber) = []
-langRules (This Distance) = []
-langRules (This Duration) = Duration.rules
-langRules (This Email) = []
-langRules (This Numeral) = Numeral.rules
-langRules (This Ordinal) = Ordinal.rules
-langRules (This PhoneNumber) = []
-langRules (This Quantity) = []
-langRules (This RegexMatch) = []
-langRules (This Temperature) = []
-langRules (This Time) = Time.rules
-langRules (This TimeGrain) = TimeGrain.rules
-langRules (This Url) = []
-langRules (This Volume) = []
-langRules (This (CustomDimension dim)) = dimLangRules NB dim
+langRules :: Seal Dimension -> [Rule]
+langRules (Seal AmountOfMoney) = AmountOfMoney.rules
+langRules (Seal CreditCardNumber) = []
+langRules (Seal Distance) = []
+langRules (Seal Duration) = Duration.rules
+langRules (Seal Email) = []
+langRules (Seal Numeral) = Numeral.rules
+langRules (Seal Ordinal) = Ordinal.rules
+langRules (Seal PhoneNumber) = []
+langRules (Seal Quantity) = []
+langRules (Seal RegexMatch) = []
+langRules (Seal Temperature) = []
+langRules (Seal Time) = Time.rules
+langRules (Seal TimeGrain) = TimeGrain.rules
+langRules (Seal Url) = []
+langRules (Seal Volume) = []
+langRules (Seal (CustomDimension dim)) = dimLangRules NB dim

--- a/Duckling/Rules/NE.hs
+++ b/Duckling/Rules/NE.hs
@@ -18,27 +18,27 @@ import Duckling.Locale
 import Duckling.Types
 import qualified Duckling.Numeral.NE.Rules as Numeral
 
-defaultRules :: Some Dimension -> [Rule]
+defaultRules :: Seal Dimension -> [Rule]
 defaultRules = langRules
 
-localeRules :: Region -> Some Dimension -> [Rule]
-localeRules region (This (CustomDimension dim)) = dimLocaleRules region dim
+localeRules :: Region -> Seal Dimension -> [Rule]
+localeRules region (Seal (CustomDimension dim)) = dimLocaleRules region dim
 localeRules _ _ = []
 
-langRules :: Some Dimension -> [Rule]
-langRules (This AmountOfMoney) = []
-langRules (This CreditCardNumber) = []
-langRules (This Distance) = []
-langRules (This Duration) = []
-langRules (This Numeral) = Numeral.rules
-langRules (This Email) = []
-langRules (This Ordinal) = []
-langRules (This PhoneNumber) = []
-langRules (This Quantity) = []
-langRules (This RegexMatch) = []
-langRules (This Temperature) = []
-langRules (This Time) = []
-langRules (This TimeGrain) = []
-langRules (This Url) = []
-langRules (This Volume) = []
-langRules (This (CustomDimension dim)) = dimLangRules NE dim
+langRules :: Seal Dimension -> [Rule]
+langRules (Seal AmountOfMoney) = []
+langRules (Seal CreditCardNumber) = []
+langRules (Seal Distance) = []
+langRules (Seal Duration) = []
+langRules (Seal Numeral) = Numeral.rules
+langRules (Seal Email) = []
+langRules (Seal Ordinal) = []
+langRules (Seal PhoneNumber) = []
+langRules (Seal Quantity) = []
+langRules (Seal RegexMatch) = []
+langRules (Seal Temperature) = []
+langRules (Seal Time) = []
+langRules (Seal TimeGrain) = []
+langRules (Seal Url) = []
+langRules (Seal Volume) = []
+langRules (Seal (CustomDimension dim)) = dimLangRules NE dim

--- a/Duckling/Rules/NL.hs
+++ b/Duckling/Rules/NL.hs
@@ -30,29 +30,29 @@ import qualified Duckling.Time.NL.NL.Rules as TimeNL
 import qualified Duckling.TimeGrain.NL.Rules as TimeGrain
 import qualified Duckling.Volume.NL.Rules as Volume
 
-defaultRules :: Some Dimension -> [Rule]
-defaultRules dim@(This Time) = TimeNL.rulesBackwardCompatible ++ langRules dim
+defaultRules :: Seal Dimension -> [Rule]
+defaultRules dim@(Seal Time) = TimeNL.rulesBackwardCompatible ++ langRules dim
 defaultRules dim = langRules dim
 
-localeRules :: Region -> Some Dimension -> [Rule]
-localeRules region (This (CustomDimension dim)) = dimLocaleRules region dim
-localeRules BE (This Time) = TimeBE.rules
+localeRules :: Region -> Seal Dimension -> [Rule]
+localeRules region (Seal (CustomDimension dim)) = dimLocaleRules region dim
+localeRules BE (Seal Time) = TimeBE.rules
 localeRules _ _ = []
 
-langRules :: Some Dimension -> [Rule]
-langRules (This AmountOfMoney) = AmountOfMoney.rules
-langRules (This CreditCardNumber) = []
-langRules (This Distance) = Distance.rules
-langRules (This Duration) = Duration.rules
-langRules (This Email) = []
-langRules (This Numeral) = Numeral.rules
-langRules (This Ordinal) = Ordinal.rules
-langRules (This PhoneNumber) = []
-langRules (This Quantity) = Quantity.rules
-langRules (This RegexMatch) = []
-langRules (This Temperature) = []
-langRules (This Time) = Time.rules
-langRules (This TimeGrain) = TimeGrain.rules
-langRules (This Url) = []
-langRules (This Volume) = Volume.rules
-langRules (This (CustomDimension dim)) = dimLangRules NL dim
+langRules :: Seal Dimension -> [Rule]
+langRules (Seal AmountOfMoney) = AmountOfMoney.rules
+langRules (Seal CreditCardNumber) = []
+langRules (Seal Distance) = Distance.rules
+langRules (Seal Duration) = Duration.rules
+langRules (Seal Email) = []
+langRules (Seal Numeral) = Numeral.rules
+langRules (Seal Ordinal) = Ordinal.rules
+langRules (Seal PhoneNumber) = []
+langRules (Seal Quantity) = Quantity.rules
+langRules (Seal RegexMatch) = []
+langRules (Seal Temperature) = []
+langRules (Seal Time) = Time.rules
+langRules (Seal TimeGrain) = TimeGrain.rules
+langRules (Seal Url) = []
+langRules (Seal Volume) = Volume.rules
+langRules (Seal (CustomDimension dim)) = dimLangRules NL dim

--- a/Duckling/Rules/PL.hs
+++ b/Duckling/Rules/PL.hs
@@ -23,27 +23,27 @@ import qualified Duckling.Ordinal.PL.Rules as Ordinal
 import qualified Duckling.Time.PL.Rules as Time
 import qualified Duckling.TimeGrain.PL.Rules as TimeGrain
 
-defaultRules :: Some Dimension -> [Rule]
+defaultRules :: Seal Dimension -> [Rule]
 defaultRules = langRules
 
-localeRules :: Region -> Some Dimension -> [Rule]
-localeRules region (This (CustomDimension dim)) = dimLocaleRules region dim
+localeRules :: Region -> Seal Dimension -> [Rule]
+localeRules region (Seal (CustomDimension dim)) = dimLocaleRules region dim
 localeRules _ _ = []
 
-langRules :: Some Dimension -> [Rule]
-langRules (This AmountOfMoney) = []
-langRules (This CreditCardNumber) = []
-langRules (This Distance) = []
-langRules (This Duration) = Duration.rules
-langRules (This Email) = []
-langRules (This Numeral) = Numeral.rules
-langRules (This Ordinal) = Ordinal.rules
-langRules (This PhoneNumber) = []
-langRules (This Quantity) = []
-langRules (This RegexMatch) = []
-langRules (This Temperature) = []
-langRules (This Time) = Time.rules
-langRules (This TimeGrain) = TimeGrain.rules
-langRules (This Url) = []
-langRules (This Volume) = []
-langRules (This (CustomDimension dim)) = dimLangRules PL dim
+langRules :: Seal Dimension -> [Rule]
+langRules (Seal AmountOfMoney) = []
+langRules (Seal CreditCardNumber) = []
+langRules (Seal Distance) = []
+langRules (Seal Duration) = Duration.rules
+langRules (Seal Email) = []
+langRules (Seal Numeral) = Numeral.rules
+langRules (Seal Ordinal) = Ordinal.rules
+langRules (Seal PhoneNumber) = []
+langRules (Seal Quantity) = []
+langRules (Seal RegexMatch) = []
+langRules (Seal Temperature) = []
+langRules (Seal Time) = Time.rules
+langRules (Seal TimeGrain) = TimeGrain.rules
+langRules (Seal Url) = []
+langRules (Seal Volume) = []
+langRules (Seal (CustomDimension dim)) = dimLangRules PL dim

--- a/Duckling/Rules/PT.hs
+++ b/Duckling/Rules/PT.hs
@@ -28,27 +28,27 @@ import qualified Duckling.Time.PT.Rules as Time
 import qualified Duckling.TimeGrain.PT.Rules as TimeGrain
 import qualified Duckling.Volume.PT.Rules as Volume
 
-defaultRules :: Some Dimension -> [Rule]
+defaultRules :: Seal Dimension -> [Rule]
 defaultRules = langRules
 
-localeRules :: Region -> Some Dimension -> [Rule]
-localeRules region (This (CustomDimension dim)) = dimLocaleRules region dim
+localeRules :: Region -> Seal Dimension -> [Rule]
+localeRules region (Seal (CustomDimension dim)) = dimLocaleRules region dim
 localeRules _ _ = []
 
-langRules :: Some Dimension -> [Rule]
-langRules (This AmountOfMoney) = AmountOfMoney.rules
-langRules (This CreditCardNumber) = []
-langRules (This Distance) = Distance.rules
-langRules (This Duration) = []
-langRules (This Email) = []
-langRules (This Numeral) = Numeral.rules
-langRules (This Ordinal) = Ordinal.rules
-langRules (This PhoneNumber) = PhoneNumber.rules
-langRules (This Quantity) = Quantity.rules
-langRules (This RegexMatch) = []
-langRules (This Temperature) = Temperature.rules
-langRules (This Time) = Time.rules
-langRules (This TimeGrain) = TimeGrain.rules
-langRules (This Url) = []
-langRules (This Volume) = Volume.rules
-langRules (This (CustomDimension dim)) = dimLangRules PT dim
+langRules :: Seal Dimension -> [Rule]
+langRules (Seal AmountOfMoney) = AmountOfMoney.rules
+langRules (Seal CreditCardNumber) = []
+langRules (Seal Distance) = Distance.rules
+langRules (Seal Duration) = []
+langRules (Seal Email) = []
+langRules (Seal Numeral) = Numeral.rules
+langRules (Seal Ordinal) = Ordinal.rules
+langRules (Seal PhoneNumber) = PhoneNumber.rules
+langRules (Seal Quantity) = Quantity.rules
+langRules (Seal RegexMatch) = []
+langRules (Seal Temperature) = Temperature.rules
+langRules (Seal Time) = Time.rules
+langRules (Seal TimeGrain) = TimeGrain.rules
+langRules (Seal Url) = []
+langRules (Seal Volume) = Volume.rules
+langRules (Seal (CustomDimension dim)) = dimLangRules PT dim

--- a/Duckling/Rules/RO.hs
+++ b/Duckling/Rules/RO.hs
@@ -28,27 +28,27 @@ import qualified Duckling.Time.RO.Rules as Time
 import qualified Duckling.TimeGrain.RO.Rules as TimeGrain
 import qualified Duckling.Volume.RO.Rules as Volume
 
-defaultRules :: Some Dimension -> [Rule]
+defaultRules :: Seal Dimension -> [Rule]
 defaultRules = langRules
 
-localeRules :: Region -> Some Dimension -> [Rule]
-localeRules region (This (CustomDimension dim)) = dimLocaleRules region dim
+localeRules :: Region -> Seal Dimension -> [Rule]
+localeRules region (Seal (CustomDimension dim)) = dimLocaleRules region dim
 localeRules _ _ = []
 
-langRules :: Some Dimension -> [Rule]
-langRules (This AmountOfMoney) = AmountOfMoney.rules
-langRules (This CreditCardNumber) = []
-langRules (This Distance) = Distance.rules
-langRules (This Duration) = Duration.rules
-langRules (This Email) = []
-langRules (This Numeral) = Numeral.rules
-langRules (This Ordinal) = Ordinal.rules
-langRules (This PhoneNumber) = []
-langRules (This Quantity) = Quantity.rules
-langRules (This RegexMatch) = []
-langRules (This Temperature) = Temperature.rules
-langRules (This Time) = Time.rules
-langRules (This TimeGrain) = TimeGrain.rules
-langRules (This Url) = []
-langRules (This Volume) = Volume.rules
-langRules (This (CustomDimension dim)) = dimLangRules RO dim
+langRules :: Seal Dimension -> [Rule]
+langRules (Seal AmountOfMoney) = AmountOfMoney.rules
+langRules (Seal CreditCardNumber) = []
+langRules (Seal Distance) = Distance.rules
+langRules (Seal Duration) = Duration.rules
+langRules (Seal Email) = []
+langRules (Seal Numeral) = Numeral.rules
+langRules (Seal Ordinal) = Ordinal.rules
+langRules (Seal PhoneNumber) = []
+langRules (Seal Quantity) = Quantity.rules
+langRules (Seal RegexMatch) = []
+langRules (Seal Temperature) = Temperature.rules
+langRules (Seal Time) = Time.rules
+langRules (Seal TimeGrain) = TimeGrain.rules
+langRules (Seal Url) = []
+langRules (Seal Volume) = Volume.rules
+langRules (Seal (CustomDimension dim)) = dimLangRules RO dim

--- a/Duckling/Rules/RU.hs
+++ b/Duckling/Rules/RU.hs
@@ -26,27 +26,27 @@ import qualified Duckling.Quantity.RU.Rules as Quantity
 import qualified Duckling.TimeGrain.RU.Rules as TimeGrain
 import qualified Duckling.Volume.RU.Rules as Volume
 
-defaultRules :: Some Dimension -> [Rule]
+defaultRules :: Seal Dimension -> [Rule]
 defaultRules = langRules
 
-localeRules :: Region -> Some Dimension -> [Rule]
-localeRules region (This (CustomDimension dim)) = dimLocaleRules region dim
+localeRules :: Region -> Seal Dimension -> [Rule]
+localeRules region (Seal (CustomDimension dim)) = dimLocaleRules region dim
 localeRules _ _ = []
 
-langRules :: Some Dimension -> [Rule]
-langRules (This AmountOfMoney) = AmountOfMoney.rules
-langRules (This CreditCardNumber) = []
-langRules (This Distance) = Distance.rules
-langRules (This Duration) = Duration.rules
-langRules (This Email) = []
-langRules (This Numeral) = Numeral.rules
-langRules (This Ordinal) = Ordinal.rules
-langRules (This PhoneNumber) = []
-langRules (This Quantity) = Quantity.rules
-langRules (This RegexMatch) = []
-langRules (This Temperature) = []
-langRules (This Time) = []
-langRules (This TimeGrain) = TimeGrain.rules
-langRules (This Url) = []
-langRules (This Volume) = Volume.rules
-langRules (This (CustomDimension dim)) = dimLangRules RU dim
+langRules :: Seal Dimension -> [Rule]
+langRules (Seal AmountOfMoney) = AmountOfMoney.rules
+langRules (Seal CreditCardNumber) = []
+langRules (Seal Distance) = Distance.rules
+langRules (Seal Duration) = Duration.rules
+langRules (Seal Email) = []
+langRules (Seal Numeral) = Numeral.rules
+langRules (Seal Ordinal) = Ordinal.rules
+langRules (Seal PhoneNumber) = []
+langRules (Seal Quantity) = Quantity.rules
+langRules (Seal RegexMatch) = []
+langRules (Seal Temperature) = []
+langRules (Seal Time) = []
+langRules (Seal TimeGrain) = TimeGrain.rules
+langRules (Seal Url) = []
+langRules (Seal Volume) = Volume.rules
+langRules (Seal (CustomDimension dim)) = dimLangRules RU dim

--- a/Duckling/Rules/SK.hs
+++ b/Duckling/Rules/SK.hs
@@ -20,27 +20,27 @@ import Duckling.Locale
 import Duckling.Types
 import qualified Duckling.Numeral.SK.Rules as Numeral
 
-defaultRules :: Some Dimension -> [Rule]
+defaultRules :: Seal Dimension -> [Rule]
 defaultRules = langRules
 
-localeRules :: Region -> Some Dimension -> [Rule]
-localeRules region (This (CustomDimension dim)) = dimLocaleRules region dim
+localeRules :: Region -> Seal Dimension -> [Rule]
+localeRules region (Seal (CustomDimension dim)) = dimLocaleRules region dim
 localeRules _ _ = []
 
-langRules :: Some Dimension -> [Rule]
-langRules (This AmountOfMoney) = []
-langRules (This CreditCardNumber) = []
-langRules (This Distance) = []
-langRules (This Duration) = []
-langRules (This Email) = []
-langRules (This Numeral) = Numeral.rules
-langRules (This Ordinal) = []
-langRules (This PhoneNumber) = []
-langRules (This Quantity) = []
-langRules (This RegexMatch) = []
-langRules (This Temperature) = []
-langRules (This Time) = []
-langRules (This TimeGrain) = []
-langRules (This Url) = []
-langRules (This Volume) = []
-langRules (This (CustomDimension dim)) = dimLangRules SK dim
+langRules :: Seal Dimension -> [Rule]
+langRules (Seal AmountOfMoney) = []
+langRules (Seal CreditCardNumber) = []
+langRules (Seal Distance) = []
+langRules (Seal Duration) = []
+langRules (Seal Email) = []
+langRules (Seal Numeral) = Numeral.rules
+langRules (Seal Ordinal) = []
+langRules (Seal PhoneNumber) = []
+langRules (Seal Quantity) = []
+langRules (Seal RegexMatch) = []
+langRules (Seal Temperature) = []
+langRules (Seal Time) = []
+langRules (Seal TimeGrain) = []
+langRules (Seal Url) = []
+langRules (Seal Volume) = []
+langRules (Seal (CustomDimension dim)) = dimLangRules SK dim

--- a/Duckling/Rules/SV.hs
+++ b/Duckling/Rules/SV.hs
@@ -25,27 +25,27 @@ import qualified Duckling.Numeral.SV.Rules as Numeral
 import qualified Duckling.Time.SV.Rules as Time
 import qualified Duckling.TimeGrain.SV.Rules as TimeGrain
 
-defaultRules :: Some Dimension -> [Rule]
+defaultRules :: Seal Dimension -> [Rule]
 defaultRules = langRules
 
-localeRules :: Region -> Some Dimension -> [Rule]
-localeRules region (This (CustomDimension dim)) = dimLocaleRules region dim
+localeRules :: Region -> Seal Dimension -> [Rule]
+localeRules region (Seal (CustomDimension dim)) = dimLocaleRules region dim
 localeRules _ _ = []
 
-langRules :: Some Dimension -> [Rule]
-langRules (This AmountOfMoney) = AmountOfMoney.rules
-langRules (This CreditCardNumber) = []
-langRules (This Distance) = Distance.rules
-langRules (This Duration) = Duration.rules
-langRules (This Email) = []
-langRules (This Numeral) = Numeral.rules
-langRules (This Ordinal) = Ordinal.rules
-langRules (This PhoneNumber) = []
-langRules (This Quantity) = []
-langRules (This RegexMatch) = []
-langRules (This Temperature) = []
-langRules (This Time) = Time.rules
-langRules (This TimeGrain) = TimeGrain.rules
-langRules (This Url) = []
-langRules (This Volume) = []
-langRules (This (CustomDimension dim)) = dimLangRules SV dim
+langRules :: Seal Dimension -> [Rule]
+langRules (Seal AmountOfMoney) = AmountOfMoney.rules
+langRules (Seal CreditCardNumber) = []
+langRules (Seal Distance) = Distance.rules
+langRules (Seal Duration) = Duration.rules
+langRules (Seal Email) = []
+langRules (Seal Numeral) = Numeral.rules
+langRules (Seal Ordinal) = Ordinal.rules
+langRules (Seal PhoneNumber) = []
+langRules (Seal Quantity) = []
+langRules (Seal RegexMatch) = []
+langRules (Seal Temperature) = []
+langRules (Seal Time) = Time.rules
+langRules (Seal TimeGrain) = TimeGrain.rules
+langRules (Seal Url) = []
+langRules (Seal Volume) = []
+langRules (Seal (CustomDimension dim)) = dimLangRules SV dim

--- a/Duckling/Rules/SW.hs
+++ b/Duckling/Rules/SW.hs
@@ -19,27 +19,27 @@ import Duckling.Locale
 import Duckling.Types
 import qualified Duckling.Numeral.SW.Rules as Numeral
 
-defaultRules :: Some Dimension -> [Rule]
+defaultRules :: Seal Dimension -> [Rule]
 defaultRules = langRules
 
-localeRules :: Region -> Some Dimension -> [Rule]
-localeRules region (This (CustomDimension dim)) = dimLocaleRules region dim
+localeRules :: Region -> Seal Dimension -> [Rule]
+localeRules region (Seal (CustomDimension dim)) = dimLocaleRules region dim
 localeRules _ _ = []
 
-langRules :: Some Dimension -> [Rule]
-langRules (This AmountOfMoney) = []
-langRules (This CreditCardNumber) = []
-langRules (This Distance) = []
-langRules (This Duration) = []
-langRules (This Email) = []
-langRules (This Numeral) = Numeral.rules
-langRules (This Ordinal) = []
-langRules (This PhoneNumber) = []
-langRules (This Quantity) = []
-langRules (This RegexMatch) = []
-langRules (This Temperature) = []
-langRules (This Time) = []
-langRules (This TimeGrain) = []
-langRules (This Url) = []
-langRules (This Volume) = []
-langRules (This (CustomDimension dim)) = dimLangRules SW dim
+langRules :: Seal Dimension -> [Rule]
+langRules (Seal AmountOfMoney) = []
+langRules (Seal CreditCardNumber) = []
+langRules (Seal Distance) = []
+langRules (Seal Duration) = []
+langRules (Seal Email) = []
+langRules (Seal Numeral) = Numeral.rules
+langRules (Seal Ordinal) = []
+langRules (Seal PhoneNumber) = []
+langRules (Seal Quantity) = []
+langRules (Seal RegexMatch) = []
+langRules (Seal Temperature) = []
+langRules (Seal Time) = []
+langRules (Seal TimeGrain) = []
+langRules (Seal Url) = []
+langRules (Seal Volume) = []
+langRules (Seal (CustomDimension dim)) = dimLangRules SW dim

--- a/Duckling/Rules/TA.hs
+++ b/Duckling/Rules/TA.hs
@@ -19,27 +19,27 @@ import Duckling.Types
 import qualified Duckling.Numeral.TA.Rules as Numeral
 import qualified Duckling.Ordinal.TA.Rules as Ordinal
 
-defaultRules :: Some Dimension -> [Rule]
+defaultRules :: Seal Dimension -> [Rule]
 defaultRules = langRules
 
-localeRules :: Region -> Some Dimension -> [Rule]
-localeRules region (This (CustomDimension dim)) = dimLocaleRules region dim
+localeRules :: Region -> Seal Dimension -> [Rule]
+localeRules region (Seal (CustomDimension dim)) = dimLocaleRules region dim
 localeRules _ _ = []
 
-langRules :: Some Dimension -> [Rule]
-langRules (This AmountOfMoney) = []
-langRules (This CreditCardNumber) = []
-langRules (This Distance) = []
-langRules (This Duration) = []
-langRules (This Numeral) = Numeral.rules
-langRules (This Email) = []
-langRules (This Ordinal) = Ordinal.rules
-langRules (This PhoneNumber) = []
-langRules (This Quantity) = []
-langRules (This RegexMatch) = []
-langRules (This Temperature) = []
-langRules (This Time) = []
-langRules (This TimeGrain) = []
-langRules (This Url) = []
-langRules (This Volume) = []
-langRules (This (CustomDimension dim)) = dimLangRules TA dim
+langRules :: Seal Dimension -> [Rule]
+langRules (Seal AmountOfMoney) = []
+langRules (Seal CreditCardNumber) = []
+langRules (Seal Distance) = []
+langRules (Seal Duration) = []
+langRules (Seal Numeral) = Numeral.rules
+langRules (Seal Email) = []
+langRules (Seal Ordinal) = Ordinal.rules
+langRules (Seal PhoneNumber) = []
+langRules (Seal Quantity) = []
+langRules (Seal RegexMatch) = []
+langRules (Seal Temperature) = []
+langRules (Seal Time) = []
+langRules (Seal TimeGrain) = []
+langRules (Seal Url) = []
+langRules (Seal Volume) = []
+langRules (Seal (CustomDimension dim)) = dimLangRules TA dim

--- a/Duckling/Rules/TH.hs
+++ b/Duckling/Rules/TH.hs
@@ -19,27 +19,27 @@ import Duckling.Locale
 import Duckling.Types
 import qualified Duckling.Numeral.TH.Rules as Numeral
 
-defaultRules :: Some Dimension -> [Rule]
+defaultRules :: Seal Dimension -> [Rule]
 defaultRules = langRules
 
-localeRules :: Region -> Some Dimension -> [Rule]
-localeRules region (This (CustomDimension dim)) = dimLocaleRules region dim
+localeRules :: Region -> Seal Dimension -> [Rule]
+localeRules region (Seal (CustomDimension dim)) = dimLocaleRules region dim
 localeRules _ _ = []
 
-langRules :: Some Dimension -> [Rule]
-langRules (This AmountOfMoney) = []
-langRules (This CreditCardNumber) = []
-langRules (This Distance) = []
-langRules (This Duration) = []
-langRules (This Email) = []
-langRules (This Numeral) = Numeral.rules
-langRules (This Ordinal) = []
-langRules (This PhoneNumber) = []
-langRules (This Quantity) = []
-langRules (This RegexMatch) = []
-langRules (This Temperature) = []
-langRules (This Time) = []
-langRules (This TimeGrain) = []
-langRules (This Url) = []
-langRules (This Volume) = []
-langRules (This (CustomDimension dim)) = dimLangRules TH dim
+langRules :: Seal Dimension -> [Rule]
+langRules (Seal AmountOfMoney) = []
+langRules (Seal CreditCardNumber) = []
+langRules (Seal Distance) = []
+langRules (Seal Duration) = []
+langRules (Seal Email) = []
+langRules (Seal Numeral) = Numeral.rules
+langRules (Seal Ordinal) = []
+langRules (Seal PhoneNumber) = []
+langRules (Seal Quantity) = []
+langRules (Seal RegexMatch) = []
+langRules (Seal Temperature) = []
+langRules (Seal Time) = []
+langRules (Seal TimeGrain) = []
+langRules (Seal Url) = []
+langRules (Seal Volume) = []
+langRules (Seal (CustomDimension dim)) = dimLangRules TH dim

--- a/Duckling/Rules/TR.hs
+++ b/Duckling/Rules/TR.hs
@@ -25,27 +25,27 @@ import qualified Duckling.Temperature.TR.Rules as Temperature
 import qualified Duckling.TimeGrain.TR.Rules as TimeGrain
 import qualified Duckling.Volume.TR.Rules as Volume
 
-defaultRules :: Some Dimension -> [Rule]
+defaultRules :: Seal Dimension -> [Rule]
 defaultRules = langRules
 
-localeRules :: Region -> Some Dimension -> [Rule]
-localeRules region (This (CustomDimension dim)) = dimLocaleRules region dim
+localeRules :: Region -> Seal Dimension -> [Rule]
+localeRules region (Seal (CustomDimension dim)) = dimLocaleRules region dim
 localeRules _ _ = []
 
-langRules :: Some Dimension -> [Rule]
-langRules (This AmountOfMoney) = []
-langRules (This CreditCardNumber) = []
-langRules (This Distance) = Distance.rules
-langRules (This Duration) = Duration.rules
-langRules (This Email) = []
-langRules (This Numeral) = Numeral.rules
-langRules (This Ordinal) = Ordinal.rules
-langRules (This PhoneNumber) = []
-langRules (This Quantity) = []
-langRules (This RegexMatch) = []
-langRules (This Temperature) = Temperature.rules
-langRules (This Time) = []
-langRules (This TimeGrain) = TimeGrain.rules
-langRules (This Url) = []
-langRules (This Volume) = Volume.rules
-langRules (This (CustomDimension dim)) = dimLangRules TR dim
+langRules :: Seal Dimension -> [Rule]
+langRules (Seal AmountOfMoney) = []
+langRules (Seal CreditCardNumber) = []
+langRules (Seal Distance) = Distance.rules
+langRules (Seal Duration) = Duration.rules
+langRules (Seal Email) = []
+langRules (Seal Numeral) = Numeral.rules
+langRules (Seal Ordinal) = Ordinal.rules
+langRules (Seal PhoneNumber) = []
+langRules (Seal Quantity) = []
+langRules (Seal RegexMatch) = []
+langRules (Seal Temperature) = Temperature.rules
+langRules (Seal Time) = []
+langRules (Seal TimeGrain) = TimeGrain.rules
+langRules (Seal Url) = []
+langRules (Seal Volume) = Volume.rules
+langRules (Seal (CustomDimension dim)) = dimLangRules TR dim

--- a/Duckling/Rules/UK.hs
+++ b/Duckling/Rules/UK.hs
@@ -23,27 +23,27 @@ import qualified Duckling.Ordinal.UK.Rules as Ordinal
 import qualified Duckling.Time.UK.Rules as Time
 import qualified Duckling.TimeGrain.UK.Rules as TimeGrain
 
-defaultRules :: Some Dimension -> [Rule]
+defaultRules :: Seal Dimension -> [Rule]
 defaultRules = langRules
 
-localeRules :: Region -> Some Dimension -> [Rule]
-localeRules region (This (CustomDimension dim)) = dimLocaleRules region dim
+localeRules :: Region -> Seal Dimension -> [Rule]
+localeRules region (Seal (CustomDimension dim)) = dimLocaleRules region dim
 localeRules _ _ = []
 
-langRules :: Some Dimension -> [Rule]
-langRules (This AmountOfMoney) = []
-langRules (This CreditCardNumber) = []
-langRules (This Distance) = []
-langRules (This Duration) = Duration.rules
-langRules (This Email) = []
-langRules (This Numeral) = Numeral.rules
-langRules (This Ordinal) = Ordinal.rules
-langRules (This PhoneNumber) = []
-langRules (This Quantity) = []
-langRules (This RegexMatch) = []
-langRules (This Temperature) = []
-langRules (This Time) = Time.rules
-langRules (This TimeGrain) = TimeGrain.rules
-langRules (This Url) = []
-langRules (This Volume) = []
-langRules (This (CustomDimension dim)) = dimLangRules UK dim
+langRules :: Seal Dimension -> [Rule]
+langRules (Seal AmountOfMoney) = []
+langRules (Seal CreditCardNumber) = []
+langRules (Seal Distance) = []
+langRules (Seal Duration) = Duration.rules
+langRules (Seal Email) = []
+langRules (Seal Numeral) = Numeral.rules
+langRules (Seal Ordinal) = Ordinal.rules
+langRules (Seal PhoneNumber) = []
+langRules (Seal Quantity) = []
+langRules (Seal RegexMatch) = []
+langRules (Seal Temperature) = []
+langRules (Seal Time) = Time.rules
+langRules (Seal TimeGrain) = TimeGrain.rules
+langRules (Seal Url) = []
+langRules (Seal Volume) = []
+langRules (Seal (CustomDimension dim)) = dimLangRules UK dim

--- a/Duckling/Rules/VI.hs
+++ b/Duckling/Rules/VI.hs
@@ -23,27 +23,27 @@ import qualified Duckling.Ordinal.VI.Rules as Ordinal
 import qualified Duckling.TimeGrain.VI.Rules as TimeGrain
 import qualified Duckling.Time.VI.Rules as Time
 
-defaultRules :: Some Dimension -> [Rule]
+defaultRules :: Seal Dimension -> [Rule]
 defaultRules = langRules
 
-localeRules :: Region -> Some Dimension -> [Rule]
-localeRules region (This (CustomDimension dim)) = dimLocaleRules region dim
+localeRules :: Region -> Seal Dimension -> [Rule]
+localeRules region (Seal (CustomDimension dim)) = dimLocaleRules region dim
 localeRules _ _ = []
 
-langRules :: Some Dimension -> [Rule]
-langRules (This AmountOfMoney) = AmountOfMoney.rules
-langRules (This CreditCardNumber) = []
-langRules (This Distance) = []
-langRules (This Duration) = []
-langRules (This Email) = []
-langRules (This Numeral) = Numeral.rules
-langRules (This Ordinal) = Ordinal.rules
-langRules (This PhoneNumber) = []
-langRules (This Quantity) = []
-langRules (This RegexMatch) = []
-langRules (This Temperature) = []
-langRules (This Time) = Time.rules
-langRules (This TimeGrain) = TimeGrain.rules
-langRules (This Url) = []
-langRules (This Volume) = []
-langRules (This (CustomDimension dim)) = dimLangRules VI dim
+langRules :: Seal Dimension -> [Rule]
+langRules (Seal AmountOfMoney) = AmountOfMoney.rules
+langRules (Seal CreditCardNumber) = []
+langRules (Seal Distance) = []
+langRules (Seal Duration) = []
+langRules (Seal Email) = []
+langRules (Seal Numeral) = Numeral.rules
+langRules (Seal Ordinal) = Ordinal.rules
+langRules (Seal PhoneNumber) = []
+langRules (Seal Quantity) = []
+langRules (Seal RegexMatch) = []
+langRules (Seal Temperature) = []
+langRules (Seal Time) = Time.rules
+langRules (Seal TimeGrain) = TimeGrain.rules
+langRules (Seal Url) = []
+langRules (Seal Volume) = []
+langRules (Seal (CustomDimension dim)) = dimLangRules VI dim

--- a/Duckling/Rules/ZH.hs
+++ b/Duckling/Rules/ZH.hs
@@ -30,31 +30,31 @@ import qualified Duckling.Time.ZH.MO.Rules as TimeMO
 import qualified Duckling.Time.ZH.TW.Rules as TimeTW
 import qualified Duckling.TimeGrain.ZH.Rules as TimeGrain
 
-defaultRules :: Some Dimension -> [Rule]
+defaultRules :: Seal Dimension -> [Rule]
 defaultRules = langRules
 
-localeRules :: Region -> Some Dimension -> [Rule]
-localeRules CN (This Time) = TimeCN.rules
-localeRules HK (This Time) = TimeHK.rules
-localeRules MO (This Time) = TimeMO.rules
-localeRules TW (This Time) = TimeTW.rules
-localeRules region (This (CustomDimension dim)) = dimLocaleRules region dim
+localeRules :: Region -> Seal Dimension -> [Rule]
+localeRules CN (Seal Time) = TimeCN.rules
+localeRules HK (Seal Time) = TimeHK.rules
+localeRules MO (Seal Time) = TimeMO.rules
+localeRules TW (Seal Time) = TimeTW.rules
+localeRules region (Seal (CustomDimension dim)) = dimLocaleRules region dim
 localeRules _ _ = []
 
-langRules :: Some Dimension -> [Rule]
-langRules (This AmountOfMoney) = AmountOfMoney.rules
-langRules (This CreditCardNumber) = []
-langRules (This Distance) = Distance.rules
-langRules (This Duration) = []
-langRules (This Email) = []
-langRules (This Numeral) = Numeral.rules
-langRules (This Ordinal) = Ordinal.rules
-langRules (This PhoneNumber) = []
-langRules (This Quantity) = Quantity.rules
-langRules (This RegexMatch) = []
-langRules (This Temperature) = Temperature.rules
-langRules (This Time) = Time.rules
-langRules (This TimeGrain) = TimeGrain.rules
-langRules (This Url) = []
-langRules (This Volume) = []
-langRules (This (CustomDimension dim)) = dimLangRules ZH dim
+langRules :: Seal Dimension -> [Rule]
+langRules (Seal AmountOfMoney) = AmountOfMoney.rules
+langRules (Seal CreditCardNumber) = []
+langRules (Seal Distance) = Distance.rules
+langRules (Seal Duration) = []
+langRules (Seal Email) = []
+langRules (Seal Numeral) = Numeral.rules
+langRules (Seal Ordinal) = Ordinal.rules
+langRules (Seal PhoneNumber) = []
+langRules (Seal Quantity) = Quantity.rules
+langRules (Seal RegexMatch) = []
+langRules (Seal Temperature) = Temperature.rules
+langRules (Seal Time) = Time.rules
+langRules (Seal TimeGrain) = TimeGrain.rules
+langRules (Seal Url) = []
+langRules (Seal Volume) = []
+langRules (Seal (CustomDimension dim)) = dimLangRules ZH dim

--- a/exe/CustomDimensionExample.hs
+++ b/exe/CustomDimensionExample.hs
@@ -21,7 +21,6 @@ import Control.Monad
 import Data.Aeson
 import Data.Hashable
 import Data.Semigroup ((<>))
-import Data.Some
 import Data.Text (Text)
 import Data.Typeable
 import GHC.Generics
@@ -107,5 +106,5 @@ myDimensionRule' = Rule
 main :: IO ()
 main = do
   let en = makeLocale EN Nothing
-  debug en "testing my dimension" [This (CustomDimension MyDimension)] >>= print
-  debug en "testing my dimension pattern match" [This (CustomDimension MyDimension)] >>= print
+  debug en "testing my dimension" [Seal (CustomDimension MyDimension)] >>= print
+  debug en "testing my dimension pattern match" [Seal (CustomDimension MyDimension)] >>= print

--- a/exe/Duckling/Ranking/Generate.hs
+++ b/exe/Duckling/Ranking/Generate.hs
@@ -95,7 +95,7 @@ regenClassifiers locale = do
 
     filepath = "Duckling/Ranking/Classifiers/" ++ moduleName ++ ".hs"
 
-    rules = rulesFor locale . HashSet.singleton $ This Time
+    rules = rulesFor locale . HashSet.singleton $ Seal Time
 
     -- | The trained classifier to write out
     classifiers = makeClassifiers rules trainSet

--- a/exe/DucklingExpensive.hs
+++ b/exe/DucklingExpensive.hs
@@ -11,7 +11,6 @@
 module Main (main) where
 
 import Control.Monad
-import Data.Some
 import System.Environment
 
 import Duckling.Debug
@@ -22,8 +21,8 @@ main :: IO ()
 main = do
   (repeatCount :: Int) <- read . head <$> getArgs
   void $ replicateM repeatCount $ void $ do
-    debug en "Monday 3rd at 9.30am or 2.30pm, Saturday 8th at 10.30am, Tuesday 11th at 2pm, Wednesday 12th at 2.30pm, Friday 14th at 12.30pm xx" [This Time]
-    debug es "Horario es de Lunes a Viernes de 2 pm a 10 pm. S\195\161bado de 9 am a 7 pm" [This Time]
+    debug en "Monday 3rd at 9.30am or 2.30pm, Saturday 8th at 10.30am, Tuesday 11th at 2pm, Wednesday 12th at 2.30pm, Friday 14th at 12.30pm xx" [Seal Time]
+    debug es "Horario es de Lunes a Viernes de 2 pm a 10 pm. S\195\161bado de 9 am a 7 pm" [Seal Time]
     where
       en = makeLocale EN Nothing
       es = makeLocale ES Nothing

--- a/exe/DucklingRequestSample.hs
+++ b/exe/DucklingRequestSample.hs
@@ -11,7 +11,6 @@
 module Main (main) where
 
 import Control.Monad
-import Data.Some
 import System.Environment
 
 import Duckling.Debug
@@ -22,14 +21,14 @@ main :: IO ()
 main = do
   (repeatCount :: Int) <- read . head <$> getArgs
   void $ replicateM repeatCount $ void $ do
-    debug en "My number is 123" [This PhoneNumber,This Distance,This Numeral,This Email]
-    debug en "Wednesday 5:00PM 3/29/2017" [This Numeral,This Time]
-    debug zh "12:30pm" [This Time]
-    debug en "tomorrow at 4pm" [This Time]
-    debug en "Tomorrow at 12.30?" [This Time]
-    debug en "Wednesday 9am" [This Time]
-    debug en "Sure do! Will 11:30 work?" [This Time,This AmountOfMoney]
-    debug en "8:00am" [This Time]
+    debug en "My number is 123" [Seal PhoneNumber,Seal Distance,Seal Numeral,Seal Email]
+    debug en "Wednesday 5:00PM 3/29/2017" [Seal Numeral,Seal Time]
+    debug zh "12:30pm" [Seal Time]
+    debug en "tomorrow at 4pm" [Seal Time]
+    debug en "Tomorrow at 12.30?" [Seal Time]
+    debug en "Wednesday 9am" [Seal Time]
+    debug en "Sure do! Will 11:30 work?" [Seal Time,Seal AmountOfMoney]
+    debug en "8:00am" [Seal Time]
     where
       en = makeLocale EN Nothing
       zh = makeLocale ZH Nothing

--- a/exe/ExampleMain.hs
+++ b/exe/ExampleMain.hs
@@ -68,8 +68,8 @@ targetsHandler = do
   writeLBS $ encode $
     HashMap.fromList . map dimText $ HashMap.toList supportedDimensions
   where
-    dimText :: (Lang, [Some Dimension]) -> (Text, [Text])
-    dimText = (Text.toLower . showt) *** map (\(This d) -> toName d)
+    dimText :: (Lang, [Seal Dimension]) -> (Text, [Text])
+    dimText = (Text.toLower . showt) *** map (\(Seal d) -> toName d)
 
 
 -- | Parse some text into the given dimensions
@@ -110,10 +110,10 @@ parseHandler tzs = do
     defaultTimeZone = "America/Los_Angeles"
     defaultLatent = False
 
-    parseDimension :: Text -> Maybe (Some Dimension)
+    parseDimension :: Text -> Maybe (Seal Dimension)
     parseDimension x = fromName x <|> fromCustomName x
       where
-        fromCustomName :: Text -> Maybe (Some Dimension)
+        fromCustomName :: Text -> Maybe (Seal Dimension)
         fromCustomName name = HashMap.lookup name m
         m = HashMap.fromList
           [ -- ("my-dimension", This (CustomDimension MyDimension))

--- a/tests/Duckling/AmountOfMoney/AR/Tests.hs
+++ b/tests/Duckling/AmountOfMoney/AR/Tests.hs
@@ -19,5 +19,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "AR Tests"
-  [ makeCorpusTest [This AmountOfMoney] corpus
+  [ makeCorpusTest [Seal AmountOfMoney] corpus
   ]

--- a/tests/Duckling/AmountOfMoney/BG/Tests.hs
+++ b/tests/Duckling/AmountOfMoney/BG/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "BG Tests"
-  [ makeCorpusTest [This AmountOfMoney] corpus
+  [ makeCorpusTest [Seal AmountOfMoney] corpus
   ]

--- a/tests/Duckling/AmountOfMoney/EN/Tests.hs
+++ b/tests/Duckling/AmountOfMoney/EN/Tests.hs
@@ -36,8 +36,8 @@ import qualified Duckling.AmountOfMoney.EN.ZA.Corpus as ZA
 
 tests :: TestTree
 tests = testGroup "EN Tests"
-  [ makeCorpusTest [This AmountOfMoney] corpus
-  , makeNegativeCorpusTest [This AmountOfMoney] negativeCorpus
+  [ makeCorpusTest [Seal AmountOfMoney] corpus
+  , makeNegativeCorpusTest [Seal AmountOfMoney] negativeCorpus
   , localeTests
   , intersectTests
   , rangeTests
@@ -47,75 +47,75 @@ tests = testGroup "EN Tests"
 localeTests :: TestTree
 localeTests = testGroup "Locale Tests"
   [ testGroup "EN_AU Tests"
-    [ makeCorpusTest [This AmountOfMoney]
+    [ makeCorpusTest [Seal AmountOfMoney]
       $ withLocale corpus localeAU AU.allExamples
-    , makeNegativeCorpusTest [This AmountOfMoney]
+    , makeNegativeCorpusTest [Seal AmountOfMoney]
       $ withLocale negativeCorpus localeAU AU.negativeExamples
     ]
    , testGroup "EN_BZ Tests"
-    [ makeCorpusTest [This AmountOfMoney]
+    [ makeCorpusTest [Seal AmountOfMoney]
       $ withLocale corpus localeBZ BZ.allExamples
-    , makeNegativeCorpusTest [This AmountOfMoney]
+    , makeNegativeCorpusTest [Seal AmountOfMoney]
       $ withLocale negativeCorpus localeBZ BZ.negativeExamples
     ]
    , testGroup "EN_CA Tests"
-    [ makeCorpusTest [This AmountOfMoney]
+    [ makeCorpusTest [Seal AmountOfMoney]
       $ withLocale corpus localeCA CA.allExamples
-    , makeNegativeCorpusTest [This AmountOfMoney]
+    , makeNegativeCorpusTest [Seal AmountOfMoney]
       $ withLocale negativeCorpus localeCA CA.negativeExamples
     ]
    , testGroup "EN_GB Tests"
-    [ makeCorpusTest [This AmountOfMoney]
+    [ makeCorpusTest [Seal AmountOfMoney]
       $ withLocale corpus localeGB GB.allExamples
-    , makeNegativeCorpusTest [This AmountOfMoney]
+    , makeNegativeCorpusTest [Seal AmountOfMoney]
       $ withLocale negativeCorpus localeGB GB.negativeExamples
     ]
    , testGroup "EN_IE Tests"
-    [ makeCorpusTest [This AmountOfMoney]
+    [ makeCorpusTest [Seal AmountOfMoney]
       $ withLocale corpus localeIE IE.allExamples
-    , makeNegativeCorpusTest [This AmountOfMoney]
+    , makeNegativeCorpusTest [Seal AmountOfMoney]
       $ withLocale negativeCorpus localeIE IE.negativeExamples
     ]
    , testGroup "EN_IN Tests"
-    [ makeCorpusTest [This AmountOfMoney]
+    [ makeCorpusTest [Seal AmountOfMoney]
       $ withLocale corpus localeIN IN.allExamples
-    , makeNegativeCorpusTest [This AmountOfMoney]
+    , makeNegativeCorpusTest [Seal AmountOfMoney]
       $ withLocale negativeCorpus localeIN IN.negativeExamples
     ]
    , testGroup "EN_JM Tests"
-    [ makeCorpusTest [This AmountOfMoney]
+    [ makeCorpusTest [Seal AmountOfMoney]
       $ withLocale corpus localeJM JM.allExamples
-    , makeNegativeCorpusTest [This AmountOfMoney]
+    , makeNegativeCorpusTest [Seal AmountOfMoney]
       $ withLocale negativeCorpus localeJM JM.negativeExamples
     ]
    , testGroup "EN_NZ Tests"
-    [ makeCorpusTest [This AmountOfMoney]
+    [ makeCorpusTest [Seal AmountOfMoney]
       $ withLocale corpus localeNZ NZ.allExamples
-    , makeNegativeCorpusTest [This AmountOfMoney]
+    , makeNegativeCorpusTest [Seal AmountOfMoney]
       $ withLocale negativeCorpus localeNZ NZ.negativeExamples
     ]
    , testGroup "EN_PH Tests"
-    [ makeCorpusTest [This AmountOfMoney]
+    [ makeCorpusTest [Seal AmountOfMoney]
       $ withLocale corpus localePH PH.allExamples
-    , makeNegativeCorpusTest [This AmountOfMoney]
+    , makeNegativeCorpusTest [Seal AmountOfMoney]
       $ withLocale negativeCorpus localePH PH.negativeExamples
     ]
     , testGroup "EN_TT Tests"
-    [ makeCorpusTest [This AmountOfMoney]
+    [ makeCorpusTest [Seal AmountOfMoney]
       $ withLocale corpus localeTT TT.allExamples
-    , makeNegativeCorpusTest [This AmountOfMoney]
+    , makeNegativeCorpusTest [Seal AmountOfMoney]
       $ withLocale negativeCorpus localeTT TT.negativeExamples
     ]
     , testGroup "EN_US Tests"
-    [ makeCorpusTest [This AmountOfMoney]
+    [ makeCorpusTest [Seal AmountOfMoney]
       $ withLocale corpus localeUS US.allExamples
-    , makeNegativeCorpusTest [This AmountOfMoney]
+    , makeNegativeCorpusTest [Seal AmountOfMoney]
       $ withLocale negativeCorpus localeUS US.negativeExamples
     ]
     , testGroup "EN_ZA Tests"
-    [ makeCorpusTest [This AmountOfMoney]
+    [ makeCorpusTest [Seal AmountOfMoney]
       $ withLocale corpus localeZA ZA.allExamples
-    , makeNegativeCorpusTest [This AmountOfMoney]
+    , makeNegativeCorpusTest [Seal AmountOfMoney]
       $ withLocale negativeCorpus localeZA ZA.negativeExamples
     ]
   ]
@@ -136,7 +136,7 @@ localeTests = testGroup "Locale Tests"
 
 intersectTests :: TestTree
 intersectTests = testCase "Intersect Test" $
-  mapM_ (analyzedNTest testContext testOptions . withTargets [This AmountOfMoney]) xs
+  mapM_ (analyzedNTest testContext testOptions . withTargets [Seal AmountOfMoney]) xs
   where
     xs = [ ("7c7", 2)
          , ("7c7c", 3)
@@ -150,7 +150,7 @@ intersectTests = testCase "Intersect Test" $
 
 rangeTests :: TestTree
 rangeTests = testCase "Range Test" $
-  mapM_ (analyzedRangeTest testContext testOptions . withTargets [This AmountOfMoney]) xs
+  mapM_ (analyzedRangeTest testContext testOptions . withTargets [Seal AmountOfMoney]) xs
   where
     xs = [ ("between 3 and 1 dollars", Range 14 23)
          , ("between 1 and between 2 and 3 dollars", Range 14 37)
@@ -159,4 +159,4 @@ rangeTests = testCase "Range Test" $
          ]
 
 latentTests :: TestTree
-latentTests = makeCorpusTest [This AmountOfMoney] latentCorpus
+latentTests = makeCorpusTest [Seal AmountOfMoney] latentCorpus

--- a/tests/Duckling/AmountOfMoney/ES/Tests.hs
+++ b/tests/Duckling/AmountOfMoney/ES/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.AmountOfMoney.ES.Corpus
 
 tests :: TestTree
 tests = testGroup "ES Tests"
-  [ makeCorpusTest [This AmountOfMoney] corpus
+  [ makeCorpusTest [Seal AmountOfMoney] corpus
   ]

--- a/tests/Duckling/AmountOfMoney/FR/Tests.hs
+++ b/tests/Duckling/AmountOfMoney/FR/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "FR Tests"
-  [ makeCorpusTest [This AmountOfMoney] corpus
+  [ makeCorpusTest [Seal AmountOfMoney] corpus
   ]

--- a/tests/Duckling/AmountOfMoney/GA/Tests.hs
+++ b/tests/Duckling/AmountOfMoney/GA/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.AmountOfMoney.GA.Corpus
 
 tests :: TestTree
 tests = testGroup "GA Tests"
-  [ makeCorpusTest [This AmountOfMoney] corpus
+  [ makeCorpusTest [Seal AmountOfMoney] corpus
   ]

--- a/tests/Duckling/AmountOfMoney/HE/Tests.hs
+++ b/tests/Duckling/AmountOfMoney/HE/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "HE Tests"
-  [ makeCorpusTest [This AmountOfMoney] corpus
+  [ makeCorpusTest [Seal AmountOfMoney] corpus
   ]

--- a/tests/Duckling/AmountOfMoney/HR/Tests.hs
+++ b/tests/Duckling/AmountOfMoney/HR/Tests.hs
@@ -17,5 +17,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "HR Tests"
-  [ makeCorpusTest [This AmountOfMoney] corpus
+  [ makeCorpusTest [Seal AmountOfMoney] corpus
   ]

--- a/tests/Duckling/AmountOfMoney/ID/Tests.hs
+++ b/tests/Duckling/AmountOfMoney/ID/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.AmountOfMoney.ID.Corpus
 
 tests :: TestTree
 tests = testGroup "ID Tests"
-  [ makeCorpusTest [This AmountOfMoney] corpus
+  [ makeCorpusTest [Seal AmountOfMoney] corpus
   ]

--- a/tests/Duckling/AmountOfMoney/IT/Tests.hs
+++ b/tests/Duckling/AmountOfMoney/IT/Tests.hs
@@ -19,5 +19,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "IT Tests"
-  [ makeCorpusTest [This AmountOfMoney] corpus
+  [ makeCorpusTest [Seal AmountOfMoney] corpus
   ]

--- a/tests/Duckling/AmountOfMoney/KA/Tests.hs
+++ b/tests/Duckling/AmountOfMoney/KA/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.AmountOfMoney.KA.Corpus
 
 tests :: TestTree
 tests = testGroup "KA Tests"
-  [ makeCorpusTest [This AmountOfMoney] corpus
+  [ makeCorpusTest [Seal AmountOfMoney] corpus
   ]

--- a/tests/Duckling/AmountOfMoney/KO/Tests.hs
+++ b/tests/Duckling/AmountOfMoney/KO/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.AmountOfMoney.KO.Corpus
 
 tests :: TestTree
 tests = testGroup "KO Tests"
-  [ makeCorpusTest [This AmountOfMoney] corpus
+  [ makeCorpusTest [Seal AmountOfMoney] corpus
   ]

--- a/tests/Duckling/AmountOfMoney/MN/Tests.hs
+++ b/tests/Duckling/AmountOfMoney/MN/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "MN Tests"
-  [ makeCorpusTest [This AmountOfMoney] corpus
+  [ makeCorpusTest [Seal AmountOfMoney] corpus
   ]

--- a/tests/Duckling/AmountOfMoney/NB/Tests.hs
+++ b/tests/Duckling/AmountOfMoney/NB/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "NB Tests"
-  [ makeCorpusTest [This AmountOfMoney] corpus
+  [ makeCorpusTest [Seal AmountOfMoney] corpus
   ]

--- a/tests/Duckling/AmountOfMoney/NL/Tests.hs
+++ b/tests/Duckling/AmountOfMoney/NL/Tests.hs
@@ -19,5 +19,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "NL Tests"
-  [ makeCorpusTest [This AmountOfMoney] corpus
+  [ makeCorpusTest [Seal AmountOfMoney] corpus
   ]

--- a/tests/Duckling/AmountOfMoney/PT/Tests.hs
+++ b/tests/Duckling/AmountOfMoney/PT/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "PT Tests"
-  [ makeCorpusTest [This AmountOfMoney] corpus
+  [ makeCorpusTest [Seal AmountOfMoney] corpus
   ]

--- a/tests/Duckling/AmountOfMoney/RO/Tests.hs
+++ b/tests/Duckling/AmountOfMoney/RO/Tests.hs
@@ -19,6 +19,6 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "RO Tests"
-  [ makeCorpusTest [This AmountOfMoney] corpus
-  , makeNegativeCorpusTest [This AmountOfMoney] negativeCorpus
+  [ makeCorpusTest [Seal AmountOfMoney] corpus
+  , makeNegativeCorpusTest [Seal AmountOfMoney] negativeCorpus
   ]

--- a/tests/Duckling/AmountOfMoney/RU/Tests.hs
+++ b/tests/Duckling/AmountOfMoney/RU/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "RU Tests"
-  [ makeCorpusTest [This AmountOfMoney] corpus
+  [ makeCorpusTest [Seal AmountOfMoney] corpus
   ]

--- a/tests/Duckling/AmountOfMoney/SV/Tests.hs
+++ b/tests/Duckling/AmountOfMoney/SV/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "SV Tests"
-  [ makeCorpusTest [This AmountOfMoney] corpus
+  [ makeCorpusTest [Seal AmountOfMoney] corpus
   ]

--- a/tests/Duckling/AmountOfMoney/VI/Tests.hs
+++ b/tests/Duckling/AmountOfMoney/VI/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "VI Tests"
-  [ makeCorpusTest [This AmountOfMoney] corpus
+  [ makeCorpusTest [Seal AmountOfMoney] corpus
   ]

--- a/tests/Duckling/AmountOfMoney/ZH/Tests.hs
+++ b/tests/Duckling/AmountOfMoney/ZH/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "ZH Tests"
-  [ makeCorpusTest [This AmountOfMoney] corpus
+  [ makeCorpusTest [Seal AmountOfMoney] corpus
   ]

--- a/tests/Duckling/Api/Tests.hs
+++ b/tests/Duckling/Api/Tests.hs
@@ -38,7 +38,7 @@ tests = testGroup "API Tests"
 
 parseTest :: TestTree
 parseTest = testCase "Parse Test" $
-  case parse sentence testContext testOptions [This Numeral] of
+  case parse sentence testContext testOptions [Seal Numeral] of
     [] -> assertFailure "empty result"
     (Entity dim body (RVal _ v) start end _ _:_) -> do
       assertEqual "dim" "number" dim
@@ -60,39 +60,39 @@ rankFilterTest :: TestTree
 rankFilterTest = testCase "Rank Filter Tests" $ do
   mapM_ check
     [ ( "in 2 minutes"
-      , [This Numeral, This Duration, This Time]
-      , [This Time]
+      , [Seal Numeral, Seal Duration, Seal Time]
+      , [Seal Time]
       )
     , ( "in 2 minutes, about 42 degrees"
-      , [This Numeral, This Temperature, This Time]
-      , [This Time, This Temperature]
+      , [Seal Numeral, Seal Temperature, Seal Time]
+      , [Seal Time, Seal Temperature]
       )
     , ( "today works... and tomorrow at 9pm too"
-      , [This Numeral, This Time]
-      , [This Time, This Time]
+      , [Seal Numeral, Seal Time]
+      , [Seal Time, Seal Time]
       )
     , ( "between 9:30 and 11:00 on thursday or Saturday and Thanksgiving Day"
-      , [This Numeral, This Time]
-      , [This Time, This Time, This Time]
+      , [Seal Numeral, Seal Time]
+      , [Seal Time, Seal Time, Seal Time]
       )
-    , ("the day after tomorrow 5pm", [This Time], [This Time])
-    , ("the day after tomorrow 5pm", [This Time, This Numeral], [This Time])
-    , ("the day after tomorrow 5pm", [], [This Time])
+    , ("the day after tomorrow 5pm", [Seal Time], [Seal Time])
+    , ("the day after tomorrow 5pm", [Seal Time, Seal Numeral], [Seal Time])
+    , ("the day after tomorrow 5pm", [], [Seal Time])
     ]
   where
-    check :: (Text, [Some Dimension], [Some Dimension]) -> IO ()
+    check :: (Text, [Seal Dimension], [Seal Dimension]) -> IO ()
     check (sentence, targets, expected) =
       let go = analyze sentence testContext testOptions $ HashSet.fromList targets
           actual = flip map go $
-                     \(Resolved{node=Node{token=Token d _}}) -> This d
+                     \(Resolved{node=Node{token=Token d _}}) -> Seal d
       in assertEqual ("wrong winners for " ++ show sentence) expected actual
 
 rankOrderTest :: TestTree
 rankOrderTest = testCase "Rank Order Tests" $ do
   mapM_ check
-    [ ("tomorrow at 5PM or 8PM", [This Time])
-    , ("321 12 3456 ... 7", [This Numeral])
-    , ("42 today 23 tomorrow", [This Numeral, This Time])
+    [ ("tomorrow at 5PM or 8PM", [Seal Time])
+    , ("321 12 3456 ... 7", [Seal Numeral])
+    , ("42 today 23 tomorrow", [Seal Numeral, Seal Time])
     ]
   where
     check (s, targets) =
@@ -104,13 +104,13 @@ rangeTest = testCase "Range Tests" $ do
   mapM_ (analyzedFirstTest testContext testOptions) xs
   where
     xs = map (\(input, targets, range) -> (input, targets, f range))
-             [ ( "order status 3233763377", [This PhoneNumber], Range 13 23 )
-             , ( "  3233763377  "         , [This PhoneNumber], Range  2 12 )
-             , ( " -3233763377"           , [This PhoneNumber], Range  2 12 )
-             , ( "  now"                  , [This Time]       , Range  2  5 )
-             , ( "   Monday  "            , [This Time]       , Range  3  9 )
-             , ( "  next   week "         , [This Time]       , Range  2 13 )
-             , ( "   42\n\n"              , [This Numeral]    , Range  3  5 )
+             [ ( "order status 3233763377", [Seal PhoneNumber], Range 13 23 )
+             , ( "  3233763377  "         , [Seal PhoneNumber], Range  2 12 )
+             , ( " -3233763377"           , [Seal PhoneNumber], Range  2 12 )
+             , ( "  now"                  , [Seal Time]       , Range  2  5 )
+             , ( "   Monday  "            , [Seal Time]       , Range  3  9 )
+             , ( "  next   week "         , [Seal Time]       , Range  2 13 )
+             , ( "   42\n\n"              , [Seal Numeral]    , Range  3  5 )
              ]
     f :: Range -> TestPredicate
     f expected _ (Resolved {range = actual}) = expected == actual
@@ -119,19 +119,19 @@ supportedDimensionsTest :: TestTree
 supportedDimensionsTest = testCase "Supported Dimensions Test" $ do
   mapM_ check
     [ ( AR
-      , [ This Email, This AmountOfMoney, This PhoneNumber, This Url
-        , This Duration, This Numeral, This Ordinal, This Time, This Volume
-        , This Temperature, This Quantity
+      , [ Seal Email, Seal AmountOfMoney, Seal PhoneNumber, Seal Url
+        , Seal Duration, Seal Numeral, Seal Ordinal, Seal Time, Seal Volume
+        , Seal Temperature, Seal Quantity
         ]
       )
     , ( PL
-      , [ This Email, This AmountOfMoney, This PhoneNumber, This Url
-        , This Duration, This Numeral, This Ordinal, This Time
+      , [ Seal Email, Seal AmountOfMoney, Seal PhoneNumber, Seal Url
+        , Seal Duration, Seal Numeral, Seal Ordinal, Seal Time
         ]
       )
     ]
   where
-    check :: (Lang, [Some Dimension]) -> IO ()
+    check :: (Lang, [Seal Dimension]) -> IO ()
     check (l, expected) = case HashMap.lookup l supportedDimensions of
       Nothing -> assertFailure $ "no dimensions for " ++ show l
       Just actual ->

--- a/tests/Duckling/CreditCardNumber/Tests.hs
+++ b/tests/Duckling/CreditCardNumber/Tests.hs
@@ -20,6 +20,6 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "CreditCardNumber Tests"
-  [ makeCorpusTest [This CreditCardNumber] corpus
-  , makeNegativeCorpusTest [This CreditCardNumber] negativeCorpus
+  [ makeCorpusTest [Seal CreditCardNumber] corpus
+  , makeNegativeCorpusTest [Seal CreditCardNumber] negativeCorpus
   ]

--- a/tests/Duckling/Distance/BG/Tests.hs
+++ b/tests/Duckling/Distance/BG/Tests.hs
@@ -19,5 +19,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "BG Tests"
-  [ makeCorpusTest [This Distance] corpus
+  [ makeCorpusTest [Seal Distance] corpus
   ]

--- a/tests/Duckling/Distance/CS/Tests.hs
+++ b/tests/Duckling/Distance/CS/Tests.hs
@@ -17,5 +17,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "CS Tests"
-  [ makeCorpusTest [This Distance] corpus
+  [ makeCorpusTest [Seal Distance] corpus
   ]

--- a/tests/Duckling/Distance/DE/Tests.hs
+++ b/tests/Duckling/Distance/DE/Tests.hs
@@ -19,5 +19,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "DE Tests"
-  [ makeCorpusTest [This Distance] corpus
+  [ makeCorpusTest [Seal Distance] corpus
   ]

--- a/tests/Duckling/Distance/EN/Tests.hs
+++ b/tests/Duckling/Distance/EN/Tests.hs
@@ -19,5 +19,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "EN Tests"
-  [ makeCorpusTest [This Distance] corpus
+  [ makeCorpusTest [Seal Distance] corpus
   ]

--- a/tests/Duckling/Distance/ES/Tests.hs
+++ b/tests/Duckling/Distance/ES/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Distance.ES.Corpus
 
 tests :: TestTree
 tests = testGroup "ES Tests"
-  [ makeCorpusTest [This Distance] corpus
+  [ makeCorpusTest [Seal Distance] corpus
   ]

--- a/tests/Duckling/Distance/FR/Tests.hs
+++ b/tests/Duckling/Distance/FR/Tests.hs
@@ -16,5 +16,5 @@ import Duckling.Distance.FR.Corpus
 
 tests :: TestTree
 tests = testGroup "FR Tests"
-  [ makeCorpusTest [This Distance] corpus
+  [ makeCorpusTest [Seal Distance] corpus
   ]

--- a/tests/Duckling/Distance/GA/Tests.hs
+++ b/tests/Duckling/Distance/GA/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "GA Tests"
-  [ makeCorpusTest [This Distance] corpus
+  [ makeCorpusTest [Seal Distance] corpus
   ]

--- a/tests/Duckling/Distance/HR/Tests.hs
+++ b/tests/Duckling/Distance/HR/Tests.hs
@@ -17,5 +17,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "HR Tests"
-  [ makeCorpusTest [This Distance] corpus
+  [ makeCorpusTest [Seal Distance] corpus
   ]

--- a/tests/Duckling/Distance/IT/Tests.hs
+++ b/tests/Duckling/Distance/IT/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "IT Tests"
-  [ makeCorpusTest [This Distance] corpus
+  [ makeCorpusTest [Seal Distance] corpus
   ]

--- a/tests/Duckling/Distance/KM/Tests.hs
+++ b/tests/Duckling/Distance/KM/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Distance.KM.Corpus
 
 tests :: TestTree
 tests = testGroup "KM Tests"
-  [ makeCorpusTest [This Distance] corpus
+  [ makeCorpusTest [Seal Distance] corpus
   ]

--- a/tests/Duckling/Distance/KO/Tests.hs
+++ b/tests/Duckling/Distance/KO/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Distance.KO.Corpus
 
 tests :: TestTree
 tests = testGroup "KO Tests"
-  [ makeCorpusTest [This Distance] corpus
+  [ makeCorpusTest [Seal Distance] corpus
   ]

--- a/tests/Duckling/Distance/MN/Tests.hs
+++ b/tests/Duckling/Distance/MN/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "MN Tests"
-  [ makeCorpusTest [This Distance] corpus
+  [ makeCorpusTest [Seal Distance] corpus
   ]

--- a/tests/Duckling/Distance/NL/Tests.hs
+++ b/tests/Duckling/Distance/NL/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Distance.NL.Corpus
 
 tests :: TestTree
 tests = testGroup "NL Tests"
-  [ makeCorpusTest [This Distance] corpus
+  [ makeCorpusTest [Seal Distance] corpus
   ]

--- a/tests/Duckling/Distance/PT/Tests.hs
+++ b/tests/Duckling/Distance/PT/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Distance.PT.Corpus
 
 tests :: TestTree
 tests = testGroup "PT Tests"
-  [ makeCorpusTest [This Distance] corpus
+  [ makeCorpusTest [Seal Distance] corpus
   ]

--- a/tests/Duckling/Distance/RO/Tests.hs
+++ b/tests/Duckling/Distance/RO/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Distance.RO.Corpus
 
 tests :: TestTree
 tests = testGroup "RO Tests"
-  [ makeCorpusTest [This Distance] corpus
+  [ makeCorpusTest [Seal Distance] corpus
   ]

--- a/tests/Duckling/Distance/RU/Tests.hs
+++ b/tests/Duckling/Distance/RU/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "RU Tests"
-  [ makeCorpusTest [This Distance] corpus
+  [ makeCorpusTest [Seal Distance] corpus
   ]

--- a/tests/Duckling/Distance/SV/Tests.hs
+++ b/tests/Duckling/Distance/SV/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "SV Tests"
-  [ makeCorpusTest [This Distance] corpus
+  [ makeCorpusTest [Seal Distance] corpus
   ]

--- a/tests/Duckling/Distance/TR/Tests.hs
+++ b/tests/Duckling/Distance/TR/Tests.hs
@@ -17,5 +17,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "TR Tests"
-  [ makeCorpusTest [This Distance] corpus
+  [ makeCorpusTest [Seal Distance] corpus
   ]

--- a/tests/Duckling/Distance/ZH/Tests.hs
+++ b/tests/Duckling/Distance/ZH/Tests.hs
@@ -23,14 +23,14 @@ import Duckling.Testing.Types
 
 tests :: TestTree
 tests = testGroup "ZH Tests"
-  [ makeCorpusTest [This Distance] corpus
+  [ makeCorpusTest [Seal Distance] corpus
   , ambiguousTests
   ]
 
 ambiguousTests :: TestTree
 ambiguousTests = testCase "Ambiguous Tests" $
   analyzedAmbiguousTest context testOptions
-    (testText, [This Distance], predicates)
+    (testText, [Seal Distance], predicates)
   where
     context = testContext {locale = makeLocale ZH Nothing}
     testText = "3千米"

--- a/tests/Duckling/Duration/AR/Tests.hs
+++ b/tests/Duckling/Duration/AR/Tests.hs
@@ -19,5 +19,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "AR Tests"
-  [ makeCorpusTest [This Duration] corpus
+  [ makeCorpusTest [Seal Duration] corpus
   ]

--- a/tests/Duckling/Duration/BG/Tests.hs
+++ b/tests/Duckling/Duration/BG/Tests.hs
@@ -19,5 +19,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "BG Tests"
-  [ makeCorpusTest [This Duration] corpus
+  [ makeCorpusTest [Seal Duration] corpus
   ]

--- a/tests/Duckling/Duration/EL/Tests.hs
+++ b/tests/Duckling/Duration/EL/Tests.hs
@@ -19,6 +19,6 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "EL Tests"
-  [ makeCorpusTest [This Duration] corpus
-  , makeNegativeCorpusTest [This Duration] negativeCorpus
+  [ makeCorpusTest [Seal Duration] corpus
+  , makeNegativeCorpusTest [Seal Duration] negativeCorpus
   ]

--- a/tests/Duckling/Duration/EN/Tests.hs
+++ b/tests/Duckling/Duration/EN/Tests.hs
@@ -19,6 +19,6 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "EN Tests"
-  [ makeCorpusTest [This Duration] corpus
-  , makeNegativeCorpusTest [This Duration] negativeCorpus
+  [ makeCorpusTest [Seal Duration] corpus
+  , makeNegativeCorpusTest [Seal Duration] negativeCorpus
   ]

--- a/tests/Duckling/Duration/ES/Tests.hs
+++ b/tests/Duckling/Duration/ES/Tests.hs
@@ -19,5 +19,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "ES Tests"
-  [ makeCorpusTest [This Duration] corpus
+  [ makeCorpusTest [Seal Duration] corpus
   ]

--- a/tests/Duckling/Duration/FR/Tests.hs
+++ b/tests/Duckling/Duration/FR/Tests.hs
@@ -19,6 +19,6 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "FR Tests"
-  [ makeCorpusTest [This Duration] corpus
-  , makeNegativeCorpusTest [This Duration] negativeCorpus
+  [ makeCorpusTest [Seal Duration] corpus
+  , makeNegativeCorpusTest [Seal Duration] negativeCorpus
   ]

--- a/tests/Duckling/Duration/GA/Tests.hs
+++ b/tests/Duckling/Duration/GA/Tests.hs
@@ -19,5 +19,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "GA Tests"
-  [ makeCorpusTest [This Duration] corpus
+  [ makeCorpusTest [Seal Duration] corpus
   ]

--- a/tests/Duckling/Duration/HI/Tests.hs
+++ b/tests/Duckling/Duration/HI/Tests.hs
@@ -19,5 +19,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "HI Tests"
-  [ makeCorpusTest [This Duration] corpus
+  [ makeCorpusTest [Seal Duration] corpus
   ]

--- a/tests/Duckling/Duration/HU/Tests.hs
+++ b/tests/Duckling/Duration/HU/Tests.hs
@@ -19,5 +19,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "HU Tests"
-  [ makeCorpusTest [This Duration] corpus
+  [ makeCorpusTest [Seal Duration] corpus
   ]

--- a/tests/Duckling/Duration/JA/Tests.hs
+++ b/tests/Duckling/Duration/JA/Tests.hs
@@ -19,5 +19,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "JA Tests"
-  [ makeCorpusTest [This Duration] corpus
+  [ makeCorpusTest [Seal Duration] corpus
   ]

--- a/tests/Duckling/Duration/KA/Tests.hs
+++ b/tests/Duckling/Duration/KA/Tests.hs
@@ -19,5 +19,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "KA Tests"
-  [ makeCorpusTest [This Duration] corpus
+  [ makeCorpusTest [Seal Duration] corpus
   ]

--- a/tests/Duckling/Duration/KO/Tests.hs
+++ b/tests/Duckling/Duration/KO/Tests.hs
@@ -19,5 +19,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "KO Tests"
-  [ makeCorpusTest [This Duration] corpus
+  [ makeCorpusTest [Seal Duration] corpus
   ]

--- a/tests/Duckling/Duration/MN/Tests.hs
+++ b/tests/Duckling/Duration/MN/Tests.hs
@@ -19,5 +19,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "MN Tests"
-  [ makeCorpusTest [This Duration] corpus
+  [ makeCorpusTest [Seal Duration] corpus
   ]

--- a/tests/Duckling/Duration/NB/Tests.hs
+++ b/tests/Duckling/Duration/NB/Tests.hs
@@ -19,5 +19,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "NB Tests"
-  [ makeCorpusTest [This Duration] corpus
+  [ makeCorpusTest [Seal Duration] corpus
   ]

--- a/tests/Duckling/Duration/NL/Tests.hs
+++ b/tests/Duckling/Duration/NL/Tests.hs
@@ -19,6 +19,6 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "NL Tests"
-  [ makeCorpusTest [This Duration] corpus
-  , makeNegativeCorpusTest [This Duration] negativeCorpus
+  [ makeCorpusTest [Seal Duration] corpus
+  , makeNegativeCorpusTest [Seal Duration] negativeCorpus
   ]

--- a/tests/Duckling/Duration/PL/Tests.hs
+++ b/tests/Duckling/Duration/PL/Tests.hs
@@ -19,5 +19,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "PL Tests"
-  [ makeCorpusTest [This Duration] corpus
+  [ makeCorpusTest [Seal Duration] corpus
   ]

--- a/tests/Duckling/Duration/PT/Tests.hs
+++ b/tests/Duckling/Duration/PT/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "PT Tests"
-  [ makeCorpusTest [This Duration] corpus
+  [ makeCorpusTest [Seal Duration] corpus
   ]

--- a/tests/Duckling/Duration/RO/Tests.hs
+++ b/tests/Duckling/Duration/RO/Tests.hs
@@ -19,5 +19,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "RO Tests"
-  [ makeCorpusTest [This Duration] corpus
+  [ makeCorpusTest [Seal Duration] corpus
   ]

--- a/tests/Duckling/Duration/RU/Tests.hs
+++ b/tests/Duckling/Duration/RU/Tests.hs
@@ -19,5 +19,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "RU Tests"
-  [ makeCorpusTest [This Duration] corpus
+  [ makeCorpusTest [Seal Duration] corpus
   ]

--- a/tests/Duckling/Duration/SV/Tests.hs
+++ b/tests/Duckling/Duration/SV/Tests.hs
@@ -19,5 +19,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "SV Tests"
-  [ makeCorpusTest [This Duration] corpus
+  [ makeCorpusTest [Seal Duration] corpus
   ]

--- a/tests/Duckling/Duration/TR/Tests.hs
+++ b/tests/Duckling/Duration/TR/Tests.hs
@@ -19,5 +19,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "TR Tests"
-  [ makeCorpusTest [This Duration] corpus
+  [ makeCorpusTest [Seal Duration] corpus
   ]

--- a/tests/Duckling/Duration/UK/Tests.hs
+++ b/tests/Duckling/Duration/UK/Tests.hs
@@ -19,6 +19,6 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "UK Tests"
-  [ makeCorpusTest [This Duration] corpus
-  , makeNegativeCorpusTest [This Duration] negativeCorpus
+  [ makeCorpusTest [Seal Duration] corpus
+  , makeNegativeCorpusTest [Seal Duration] negativeCorpus
   ]

--- a/tests/Duckling/Duration/ZH/Tests.hs
+++ b/tests/Duckling/Duration/ZH/Tests.hs
@@ -20,5 +20,5 @@ import Duckling.Testing.Types
 
 tests :: TestTree
 tests = testGroup "ZH Tests"
-  [ makeCorpusTest [This Duration] corpus
+  [ makeCorpusTest [Seal Duration] corpus
   ]

--- a/tests/Duckling/Email/DE/Tests.hs
+++ b/tests/Duckling/Email/DE/Tests.hs
@@ -18,6 +18,6 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "DE Tests"
-  [ makeCorpusTest [This Email] corpus
-  , makeNegativeCorpusTest [This Email] negativeCorpus
+  [ makeCorpusTest [Seal Email] corpus
+  , makeNegativeCorpusTest [Seal Email] negativeCorpus
   ]

--- a/tests/Duckling/Email/EN/Tests.hs
+++ b/tests/Duckling/Email/EN/Tests.hs
@@ -18,6 +18,6 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "EN Tests"
-  [ makeCorpusTest [This Email] corpus
-  , makeNegativeCorpusTest [This Email] negativeCorpus
+  [ makeCorpusTest [Seal Email] corpus
+  , makeNegativeCorpusTest [Seal Email] negativeCorpus
   ]

--- a/tests/Duckling/Email/FR/Tests.hs
+++ b/tests/Duckling/Email/FR/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "FR Tests"
-  [ makeCorpusTest [This Email] corpus
+  [ makeCorpusTest [Seal Email] corpus
   ]

--- a/tests/Duckling/Email/IS/Tests.hs
+++ b/tests/Duckling/Email/IS/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "IS Tests"
-  [ makeCorpusTest [This Email] corpus
+  [ makeCorpusTest [Seal Email] corpus
   ]

--- a/tests/Duckling/Email/IT/Tests.hs
+++ b/tests/Duckling/Email/IT/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "IT Tests"
-  [ makeCorpusTest [This Email] corpus
+  [ makeCorpusTest [Seal Email] corpus
   ]

--- a/tests/Duckling/Email/Tests.hs
+++ b/tests/Duckling/Email/Tests.hs
@@ -24,8 +24,8 @@ import qualified Duckling.Email.IT.Tests as IT
 
 tests :: TestTree
 tests = testGroup "Email Tests"
-  [ makeCorpusTest [This Email] corpus
-  , makeNegativeCorpusTest [This Email] negativeCorpus
+  [ makeCorpusTest [Seal Email] corpus
+  , makeNegativeCorpusTest [Seal Email] negativeCorpus
   , DE.tests
   , EN.tests
   , FR.tests

--- a/tests/Duckling/Numeral/AF/Tests.hs
+++ b/tests/Duckling/Numeral/AF/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "AF Tests"
-  [ makeCorpusTest [This Numeral] corpus
+  [ makeCorpusTest [Seal Numeral] corpus
   ]

--- a/tests/Duckling/Numeral/AR/Tests.hs
+++ b/tests/Duckling/Numeral/AR/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "AR Tests"
-  [ makeCorpusTest [This Numeral] corpus
+  [ makeCorpusTest [Seal Numeral] corpus
   ]

--- a/tests/Duckling/Numeral/BG/Tests.hs
+++ b/tests/Duckling/Numeral/BG/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "BG Tests"
-  [ makeCorpusTest [This Numeral] corpus
+  [ makeCorpusTest [Seal Numeral] corpus
   ]

--- a/tests/Duckling/Numeral/BN/Tests.hs
+++ b/tests/Duckling/Numeral/BN/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "BN Tests"
-  [ makeCorpusTest [This Numeral] corpus
+  [ makeCorpusTest [Seal Numeral] corpus
   ]

--- a/tests/Duckling/Numeral/CS/Tests.hs
+++ b/tests/Duckling/Numeral/CS/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "CS Tests"
-  [ makeCorpusTest [This Numeral] corpus
+  [ makeCorpusTest [Seal Numeral] corpus
   ]

--- a/tests/Duckling/Numeral/DA/Tests.hs
+++ b/tests/Duckling/Numeral/DA/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "DA Tests"
-  [ makeCorpusTest [This Numeral] corpus
+  [ makeCorpusTest [Seal Numeral] corpus
   ]

--- a/tests/Duckling/Numeral/DE/Tests.hs
+++ b/tests/Duckling/Numeral/DE/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "DE Tests"
-  [ makeCorpusTest [This Numeral] corpus
+  [ makeCorpusTest [Seal Numeral] corpus
   ]

--- a/tests/Duckling/Numeral/EL/Tests.hs
+++ b/tests/Duckling/Numeral/EL/Tests.hs
@@ -17,5 +17,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "EL Tests"
-  [ makeCorpusTest [This Numeral] corpus
+  [ makeCorpusTest [Seal Numeral] corpus
   ]

--- a/tests/Duckling/Numeral/EN/Tests.hs
+++ b/tests/Duckling/Numeral/EN/Tests.hs
@@ -25,7 +25,7 @@ import Duckling.Types (Range(..))
 
 tests :: TestTree
 tests = testGroup "EN Tests"
-  [ makeCorpusTest [This Numeral] corpus
+  [ makeCorpusTest [Seal Numeral] corpus
   , surroundTests
   , intersectTests
   , rangeTests
@@ -34,7 +34,7 @@ tests = testGroup "EN Tests"
 surroundTests :: TestTree
 surroundTests = testCase "Surround Tests" $
   mapM_ (analyzedFirstTest testContext testOptions .
-    withTargets [This Numeral]) xs
+    withTargets [Seal Numeral]) xs
   where
     xs = concat
       [ examples (NumeralValue 3)
@@ -51,14 +51,14 @@ surroundTests = testCase "Surround Tests" $
 
 intersectTests :: TestTree
 intersectTests = testCase "Intersect Test" $
-  mapM_ (analyzedNTest testContext testOptions . withTargets [This Numeral]) xs
+  mapM_ (analyzedNTest testContext testOptions . withTargets [Seal Numeral]) xs
   where
     xs = [ ("10 millions minus 10", 2)
          ]
 
 rangeTests :: TestTree
 rangeTests = testCase "Range Test" $
-  mapM_ (analyzedRangeTest testContext testOptions . withTargets [This Numeral]) xs
+  mapM_ (analyzedRangeTest testContext testOptions . withTargets [Seal Numeral]) xs
   where
     xs = [ ("negative negative 5", Range 9 19) -- prevent double negatives
          , ("negative-5", Range 8 10) -- prevent double negatives

--- a/tests/Duckling/Numeral/ES/Tests.hs
+++ b/tests/Duckling/Numeral/ES/Tests.hs
@@ -33,32 +33,32 @@ import qualified Duckling.Region as R
 
 tests :: TestTree
 tests = testGroup "ES Tests"
-  [ makeCorpusTest [This Numeral] corpus
+  [ makeCorpusTest [Seal Numeral] corpus
   , localeTests
   ]
 
 localeTests :: TestTree
 localeTests = testGroup "Locale Tests"
   [ testGroup "ES_AR Tests"
-    [ makeCorpusTest [This Numeral] $ withLocale corpus localeAR AR.allExamples
+    [ makeCorpusTest [Seal Numeral] $ withLocale corpus localeAR AR.allExamples
     ]
   , testGroup "ES_CL Tests"
-    [ makeCorpusTest [This Numeral] $ withLocale corpus localeCL CL.allExamples
+    [ makeCorpusTest [Seal Numeral] $ withLocale corpus localeCL CL.allExamples
     ]
   , testGroup "ES_CO Tests"
-    [ makeCorpusTest [This Numeral] $ withLocale corpus localeCO CO.allExamples
+    [ makeCorpusTest [Seal Numeral] $ withLocale corpus localeCO CO.allExamples
     ]
   , testGroup "ES_ES Tests"
-    [ makeCorpusTest [This Numeral] $ withLocale corpus localeES ES.allExamples
+    [ makeCorpusTest [Seal Numeral] $ withLocale corpus localeES ES.allExamples
     ]
   , testGroup "ES_MX Tests"
-    [ makeCorpusTest [This Numeral] $ withLocale corpus localeMX MX.allExamples
+    [ makeCorpusTest [Seal Numeral] $ withLocale corpus localeMX MX.allExamples
     ]
   , testGroup "ES_PE Tests"
-    [ makeCorpusTest [This Numeral] $ withLocale corpus localePE PE.allExamples
+    [ makeCorpusTest [Seal Numeral] $ withLocale corpus localePE PE.allExamples
     ]
   , testGroup "ES_VE Tests"
-    [ makeCorpusTest [This Numeral] $ withLocale corpus localeVE VE.allExamples
+    [ makeCorpusTest [Seal Numeral] $ withLocale corpus localeVE VE.allExamples
     ]
   ]
   where

--- a/tests/Duckling/Numeral/ET/Tests.hs
+++ b/tests/Duckling/Numeral/ET/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "ET Tests"
-  [ makeCorpusTest [This Numeral] corpus
+  [ makeCorpusTest [Seal Numeral] corpus
   ]

--- a/tests/Duckling/Numeral/FI/Tests.hs
+++ b/tests/Duckling/Numeral/FI/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "FI Tests"
-  [ makeCorpusTest [This Numeral] corpus
+  [ makeCorpusTest [Seal Numeral] corpus
   ]

--- a/tests/Duckling/Numeral/FR/Tests.hs
+++ b/tests/Duckling/Numeral/FR/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "FR Tests"
-  [ makeCorpusTest [This Numeral] corpus
+  [ makeCorpusTest [Seal Numeral] corpus
   ]

--- a/tests/Duckling/Numeral/GA/Tests.hs
+++ b/tests/Duckling/Numeral/GA/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "GA Tests"
-  [ makeCorpusTest [This Numeral] corpus
+  [ makeCorpusTest [Seal Numeral] corpus
   ]

--- a/tests/Duckling/Numeral/HE/Tests.hs
+++ b/tests/Duckling/Numeral/HE/Tests.hs
@@ -17,5 +17,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "HE Tests"
-  [ makeCorpusTest [This Numeral] corpus
+  [ makeCorpusTest [Seal Numeral] corpus
   ]

--- a/tests/Duckling/Numeral/HI/Tests.hs
+++ b/tests/Duckling/Numeral/HI/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "HI Tests"
-  [ makeCorpusTest [This Numeral] corpus
+  [ makeCorpusTest [Seal Numeral] corpus
   ]

--- a/tests/Duckling/Numeral/HR/Tests.hs
+++ b/tests/Duckling/Numeral/HR/Tests.hs
@@ -17,5 +17,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "HR Tests"
-  [ makeCorpusTest [This Numeral] corpus
+  [ makeCorpusTest [Seal Numeral] corpus
   ]

--- a/tests/Duckling/Numeral/HU/Tests.hs
+++ b/tests/Duckling/Numeral/HU/Tests.hs
@@ -17,5 +17,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "HU Tests"
-  [ makeCorpusTest [This Numeral] corpus
+  [ makeCorpusTest [Seal Numeral] corpus
   ]

--- a/tests/Duckling/Numeral/ID/Tests.hs
+++ b/tests/Duckling/Numeral/ID/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "ID Tests"
-  [ makeCorpusTest [This Numeral] corpus
+  [ makeCorpusTest [Seal Numeral] corpus
   ]

--- a/tests/Duckling/Numeral/IS/Tests.hs
+++ b/tests/Duckling/Numeral/IS/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "IS Tests"
-  [ makeCorpusTest [This Numeral] corpus
+  [ makeCorpusTest [Seal Numeral] corpus
   ]

--- a/tests/Duckling/Numeral/IT/Tests.hs
+++ b/tests/Duckling/Numeral/IT/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "IT Tests"
-  [ makeCorpusTest [This Numeral] corpus
+  [ makeCorpusTest [Seal Numeral] corpus
   ]

--- a/tests/Duckling/Numeral/JA/Tests.hs
+++ b/tests/Duckling/Numeral/JA/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "JA Tests"
-  [ makeCorpusTest [This Numeral] corpus
+  [ makeCorpusTest [Seal Numeral] corpus
   ]

--- a/tests/Duckling/Numeral/KA/Tests.hs
+++ b/tests/Duckling/Numeral/KA/Tests.hs
@@ -17,5 +17,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "KA Tests"
-  [ makeCorpusTest [This Numeral] corpus
+  [ makeCorpusTest [Seal Numeral] corpus
   ]

--- a/tests/Duckling/Numeral/KM/Tests.hs
+++ b/tests/Duckling/Numeral/KM/Tests.hs
@@ -17,5 +17,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "KM Tests"
-  [ makeCorpusTest [This Numeral] corpus
+  [ makeCorpusTest [Seal Numeral] corpus
   ]

--- a/tests/Duckling/Numeral/KN/Tests.hs
+++ b/tests/Duckling/Numeral/KN/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "KN Tests"
-  [ makeCorpusTest [This Numeral] corpus
+  [ makeCorpusTest [Seal Numeral] corpus
   ]

--- a/tests/Duckling/Numeral/KO/Tests.hs
+++ b/tests/Duckling/Numeral/KO/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "KO Tests"
-  [ makeCorpusTest [This Numeral] corpus
+  [ makeCorpusTest [Seal Numeral] corpus
   ]

--- a/tests/Duckling/Numeral/LO/Tests.hs
+++ b/tests/Duckling/Numeral/LO/Tests.hs
@@ -17,5 +17,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "LO Tests"
-  [ makeCorpusTest [This Numeral] corpus
+  [ makeCorpusTest [Seal Numeral] corpus
   ]

--- a/tests/Duckling/Numeral/ML/Tests.hs
+++ b/tests/Duckling/Numeral/ML/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "ML Tests"
-  [ makeCorpusTest [This Numeral] corpus
+  [ makeCorpusTest [Seal Numeral] corpus
   ]

--- a/tests/Duckling/Numeral/MN/Tests.hs
+++ b/tests/Duckling/Numeral/MN/Tests.hs
@@ -17,5 +17,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "MN Tests"
-  [ makeCorpusTest [This Numeral] corpus
+  [ makeCorpusTest [Seal Numeral] corpus
   ]

--- a/tests/Duckling/Numeral/MY/Tests.hs
+++ b/tests/Duckling/Numeral/MY/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "MY Tests"
-  [ makeCorpusTest [This Numeral] corpus
+  [ makeCorpusTest [Seal Numeral] corpus
   ]

--- a/tests/Duckling/Numeral/NB/Tests.hs
+++ b/tests/Duckling/Numeral/NB/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "NB Tests"
-  [ makeCorpusTest [This Numeral] corpus
+  [ makeCorpusTest [Seal Numeral] corpus
   ]

--- a/tests/Duckling/Numeral/NE/Tests.hs
+++ b/tests/Duckling/Numeral/NE/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "NE Tests"
-  [ makeCorpusTest [This Numeral] corpus
+  [ makeCorpusTest [Seal Numeral] corpus
   ]

--- a/tests/Duckling/Numeral/NL/Tests.hs
+++ b/tests/Duckling/Numeral/NL/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "NL Tests"
-  [ makeCorpusTest [This Numeral] corpus
+  [ makeCorpusTest [Seal Numeral] corpus
   ]

--- a/tests/Duckling/Numeral/PL/Tests.hs
+++ b/tests/Duckling/Numeral/PL/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "PL Tests"
-  [ makeCorpusTest [This Numeral] corpus
+  [ makeCorpusTest [Seal Numeral] corpus
   ]

--- a/tests/Duckling/Numeral/PT/Tests.hs
+++ b/tests/Duckling/Numeral/PT/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "PT Tests"
-  [ makeCorpusTest [This Numeral] corpus
+  [ makeCorpusTest [Seal Numeral] corpus
   ]

--- a/tests/Duckling/Numeral/RO/Tests.hs
+++ b/tests/Duckling/Numeral/RO/Tests.hs
@@ -23,13 +23,13 @@ import Duckling.Testing.Types
 
 tests :: TestTree
 tests = testGroup "RO Tests"
-  [ makeCorpusTest [This Numeral] corpus
+  [ makeCorpusTest [Seal Numeral] corpus
   , intersectTests
   ]
 
 intersectTests :: TestTree
 intersectTests = testCase "Intersect Test" $
-  mapM_ (analyzedNTest context testOptions . withTargets [This Numeral])
+  mapM_ (analyzedNTest context testOptions . withTargets [Seal Numeral])
     [ ("19 de milioane", 2) -- make sure ruleMultiplyDe only takes >= 20
     ]
   where

--- a/tests/Duckling/Numeral/RU/Tests.hs
+++ b/tests/Duckling/Numeral/RU/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "RU Tests"
-  [ makeCorpusTest [This Numeral] corpus
+  [ makeCorpusTest [Seal Numeral] corpus
   ]

--- a/tests/Duckling/Numeral/SK/Tests.hs
+++ b/tests/Duckling/Numeral/SK/Tests.hs
@@ -19,5 +19,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "SK Tests"
-  [ makeCorpusTest [This Numeral] corpus
+  [ makeCorpusTest [Seal Numeral] corpus
   ]

--- a/tests/Duckling/Numeral/SV/Tests.hs
+++ b/tests/Duckling/Numeral/SV/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "SV Tests"
-  [ makeCorpusTest [This Numeral] corpus
+  [ makeCorpusTest [Seal Numeral] corpus
   ]

--- a/tests/Duckling/Numeral/SW/Tests.hs
+++ b/tests/Duckling/Numeral/SW/Tests.hs
@@ -17,5 +17,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "SW Tests"
-  [ makeCorpusTest [This Numeral] corpus
+  [ makeCorpusTest [Seal Numeral] corpus
   ]

--- a/tests/Duckling/Numeral/TA/Tests.hs
+++ b/tests/Duckling/Numeral/TA/Tests.hs
@@ -17,5 +17,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "TA Tests"
-  [ makeCorpusTest [This Numeral] corpus
+  [ makeCorpusTest [Seal Numeral] corpus
   ]

--- a/tests/Duckling/Numeral/TH/Tests.hs
+++ b/tests/Duckling/Numeral/TH/Tests.hs
@@ -17,5 +17,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "TH Tests"
-  [ makeCorpusTest [This Numeral] corpus
+  [ makeCorpusTest [Seal Numeral] corpus
   ]

--- a/tests/Duckling/Numeral/TR/Tests.hs
+++ b/tests/Duckling/Numeral/TR/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "TR Tests"
-  [ makeCorpusTest [This Numeral] corpus
+  [ makeCorpusTest [Seal Numeral] corpus
   ]

--- a/tests/Duckling/Numeral/UK/Tests.hs
+++ b/tests/Duckling/Numeral/UK/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "UK Tests"
-  [ makeCorpusTest [This Numeral] corpus
+  [ makeCorpusTest [Seal Numeral] corpus
   ]

--- a/tests/Duckling/Numeral/VI/Tests.hs
+++ b/tests/Duckling/Numeral/VI/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "VI Tests"
-  [ makeCorpusTest [This Numeral] corpus
+  [ makeCorpusTest [Seal Numeral] corpus
   ]

--- a/tests/Duckling/Numeral/ZH/Tests.hs
+++ b/tests/Duckling/Numeral/ZH/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "ZH Tests"
-  [ makeCorpusTest [This Numeral] corpus
+  [ makeCorpusTest [Seal Numeral] corpus
   ]

--- a/tests/Duckling/Ordinal/AR/Tests.hs
+++ b/tests/Duckling/Ordinal/AR/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "AR Tests"
-  [ makeCorpusTest [This Ordinal] corpus
+  [ makeCorpusTest [Seal Ordinal] corpus
   ]

--- a/tests/Duckling/Ordinal/BG/Tests.hs
+++ b/tests/Duckling/Ordinal/BG/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "BG Tests"
-  [ makeCorpusTest [This Ordinal] corpus
+  [ makeCorpusTest [Seal Ordinal] corpus
   ]

--- a/tests/Duckling/Ordinal/DA/Tests.hs
+++ b/tests/Duckling/Ordinal/DA/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "DA Tests"
-  [ makeCorpusTest [This Ordinal] corpus
+  [ makeCorpusTest [Seal Ordinal] corpus
   ]

--- a/tests/Duckling/Ordinal/DE/Tests.hs
+++ b/tests/Duckling/Ordinal/DE/Tests.hs
@@ -18,6 +18,6 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "DE Tests"
-  [ makeCorpusTest [This Ordinal] corpus
-  , makeNegativeCorpusTest [This Ordinal] negativeCorpus
+  [ makeCorpusTest [Seal Ordinal] corpus
+  , makeNegativeCorpusTest [Seal Ordinal] negativeCorpus
   ]

--- a/tests/Duckling/Ordinal/EL/Tests.hs
+++ b/tests/Duckling/Ordinal/EL/Tests.hs
@@ -19,5 +19,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "EL Tests"
-  [ makeCorpusTest [This Ordinal] corpus
+  [ makeCorpusTest [Seal Ordinal] corpus
   ]

--- a/tests/Duckling/Ordinal/EN/Tests.hs
+++ b/tests/Duckling/Ordinal/EN/Tests.hs
@@ -19,5 +19,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "EN Tests"
-  [ makeCorpusTest [This Ordinal] corpus
+  [ makeCorpusTest [Seal Ordinal] corpus
   ]

--- a/tests/Duckling/Ordinal/ES/Tests.hs
+++ b/tests/Duckling/Ordinal/ES/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "ES Tests"
-  [ makeCorpusTest [This Ordinal] corpus
+  [ makeCorpusTest [Seal Ordinal] corpus
   ]

--- a/tests/Duckling/Ordinal/ET/Tests.hs
+++ b/tests/Duckling/Ordinal/ET/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "ET Tests"
-  [ makeCorpusTest [This Ordinal] corpus
+  [ makeCorpusTest [Seal Ordinal] corpus
   ]

--- a/tests/Duckling/Ordinal/FR/Tests.hs
+++ b/tests/Duckling/Ordinal/FR/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "FR Tests"
-  [ makeCorpusTest [This Ordinal] corpus
+  [ makeCorpusTest [Seal Ordinal] corpus
   ]

--- a/tests/Duckling/Ordinal/GA/Tests.hs
+++ b/tests/Duckling/Ordinal/GA/Tests.hs
@@ -19,5 +19,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "GA Tests"
-  [ makeCorpusTest [This Ordinal] corpus
+  [ makeCorpusTest [Seal Ordinal] corpus
   ]

--- a/tests/Duckling/Ordinal/HE/Tests.hs
+++ b/tests/Duckling/Ordinal/HE/Tests.hs
@@ -17,5 +17,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "HE Tests"
-  [ makeCorpusTest [This Ordinal] corpus
+  [ makeCorpusTest [Seal Ordinal] corpus
   ]

--- a/tests/Duckling/Ordinal/HI/Tests.hs
+++ b/tests/Duckling/Ordinal/HI/Tests.hs
@@ -19,5 +19,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "HI Tests"
-  [ makeCorpusTest [This Ordinal] corpus
+  [ makeCorpusTest [Seal Ordinal] corpus
   ]

--- a/tests/Duckling/Ordinal/HR/Tests.hs
+++ b/tests/Duckling/Ordinal/HR/Tests.hs
@@ -17,5 +17,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "HR Tests"
-  [ makeCorpusTest [This Ordinal] corpus
+  [ makeCorpusTest [Seal Ordinal] corpus
   ]

--- a/tests/Duckling/Ordinal/HU/Tests.hs
+++ b/tests/Duckling/Ordinal/HU/Tests.hs
@@ -19,5 +19,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "HU Tests"
-  [ makeCorpusTest [This Ordinal] corpus
+  [ makeCorpusTest [Seal Ordinal] corpus
   ]

--- a/tests/Duckling/Ordinal/ID/Tests.hs
+++ b/tests/Duckling/Ordinal/ID/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "ID Tests"
-  [ makeCorpusTest [This Ordinal] corpus
+  [ makeCorpusTest [Seal Ordinal] corpus
   ]

--- a/tests/Duckling/Ordinal/IT/Tests.hs
+++ b/tests/Duckling/Ordinal/IT/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "IT Tests"
-  [ makeCorpusTest [This Ordinal] corpus
+  [ makeCorpusTest [Seal Ordinal] corpus
   ]

--- a/tests/Duckling/Ordinal/JA/Tests.hs
+++ b/tests/Duckling/Ordinal/JA/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "JA Tests"
-  [ makeCorpusTest [This Ordinal] corpus
+  [ makeCorpusTest [Seal Ordinal] corpus
   ]

--- a/tests/Duckling/Ordinal/KA/Tests.hs
+++ b/tests/Duckling/Ordinal/KA/Tests.hs
@@ -19,5 +19,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "KA Tests"
-  [ makeCorpusTest [This Ordinal] corpus
+  [ makeCorpusTest [Seal Ordinal] corpus
   ]

--- a/tests/Duckling/Ordinal/KM/Tests.hs
+++ b/tests/Duckling/Ordinal/KM/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "KM Tests"
-  [ makeCorpusTest [This Ordinal] corpus
+  [ makeCorpusTest [Seal Ordinal] corpus
   ]

--- a/tests/Duckling/Ordinal/KO/Tests.hs
+++ b/tests/Duckling/Ordinal/KO/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "KO Tests"
-  [ makeCorpusTest [This Ordinal] corpus
+  [ makeCorpusTest [Seal Ordinal] corpus
   ]

--- a/tests/Duckling/Ordinal/ML/Tests.hs
+++ b/tests/Duckling/Ordinal/ML/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "ML Tests"
-  [ makeCorpusTest [This Ordinal] corpus
+  [ makeCorpusTest [Seal Ordinal] corpus
   ]

--- a/tests/Duckling/Ordinal/MN/Tests.hs
+++ b/tests/Duckling/Ordinal/MN/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "MN Tests"
-  [ makeCorpusTest [This Ordinal] corpus
+  [ makeCorpusTest [Seal Ordinal] corpus
   ]

--- a/tests/Duckling/Ordinal/NB/Tests.hs
+++ b/tests/Duckling/Ordinal/NB/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "NB Tests"
-  [ makeCorpusTest [This Ordinal] corpus
+  [ makeCorpusTest [Seal Ordinal] corpus
   ]

--- a/tests/Duckling/Ordinal/NL/Tests.hs
+++ b/tests/Duckling/Ordinal/NL/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "NL Tests"
-  [ makeCorpusTest [This Ordinal] corpus
+  [ makeCorpusTest [Seal Ordinal] corpus
   ]

--- a/tests/Duckling/Ordinal/PL/Tests.hs
+++ b/tests/Duckling/Ordinal/PL/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "PL Tests"
-  [ makeCorpusTest [This Ordinal] corpus
+  [ makeCorpusTest [Seal Ordinal] corpus
   ]

--- a/tests/Duckling/Ordinal/PT/Tests.hs
+++ b/tests/Duckling/Ordinal/PT/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "PT Tests"
-  [ makeCorpusTest [This Ordinal] corpus
+  [ makeCorpusTest [Seal Ordinal] corpus
   ]

--- a/tests/Duckling/Ordinal/RO/Tests.hs
+++ b/tests/Duckling/Ordinal/RO/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "RO Tests"
-  [ makeCorpusTest [This Ordinal] corpus
+  [ makeCorpusTest [Seal Ordinal] corpus
   ]

--- a/tests/Duckling/Ordinal/RU/Tests.hs
+++ b/tests/Duckling/Ordinal/RU/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "RU Tests"
-  [ makeCorpusTest [This Ordinal] corpus
+  [ makeCorpusTest [Seal Ordinal] corpus
   ]

--- a/tests/Duckling/Ordinal/SV/Tests.hs
+++ b/tests/Duckling/Ordinal/SV/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "SV Tests"
-  [ makeCorpusTest [This Ordinal] corpus
+  [ makeCorpusTest [Seal Ordinal] corpus
   ]

--- a/tests/Duckling/Ordinal/TA/Tests.hs
+++ b/tests/Duckling/Ordinal/TA/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "TA Tests"
-  [ makeCorpusTest [This Ordinal] corpus
+  [ makeCorpusTest [Seal Ordinal] corpus
   ]

--- a/tests/Duckling/Ordinal/TR/Tests.hs
+++ b/tests/Duckling/Ordinal/TR/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "TR Tests"
-  [ makeCorpusTest [This Ordinal] corpus
+  [ makeCorpusTest [Seal Ordinal] corpus
   ]

--- a/tests/Duckling/Ordinal/UK/Tests.hs
+++ b/tests/Duckling/Ordinal/UK/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "UK Tests"
-  [ makeCorpusTest [This Ordinal] corpus
+  [ makeCorpusTest [Seal Ordinal] corpus
   ]

--- a/tests/Duckling/Ordinal/VI/Tests.hs
+++ b/tests/Duckling/Ordinal/VI/Tests.hs
@@ -17,5 +17,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "VI Tests"
-  [ makeCorpusTest [This Ordinal] corpus
+  [ makeCorpusTest [Seal Ordinal] corpus
   ]

--- a/tests/Duckling/Ordinal/ZH/Tests.hs
+++ b/tests/Duckling/Ordinal/ZH/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "ZH Tests"
-  [ makeCorpusTest [This Ordinal] corpus
+  [ makeCorpusTest [Seal Ordinal] corpus
   ]

--- a/tests/Duckling/PhoneNumber/AR/Tests.hs
+++ b/tests/Duckling/PhoneNumber/AR/Tests.hs
@@ -18,6 +18,6 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "PhoneNumber Tests"
-  [ makeCorpusTest [This PhoneNumber] corpus
-  , makeNegativeCorpusTest [This PhoneNumber] negativeCorpus
+  [ makeCorpusTest [Seal PhoneNumber] corpus
+  , makeNegativeCorpusTest [Seal PhoneNumber] negativeCorpus
   ]

--- a/tests/Duckling/PhoneNumber/PT/Tests.hs
+++ b/tests/Duckling/PhoneNumber/PT/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "PhoneNumber Tests"
-  [ makeCorpusTest [This PhoneNumber] corpus
+  [ makeCorpusTest [Seal PhoneNumber] corpus
   ]

--- a/tests/Duckling/PhoneNumber/Tests.hs
+++ b/tests/Duckling/PhoneNumber/Tests.hs
@@ -26,8 +26,8 @@ import qualified Duckling.PhoneNumber.PT.Tests as PT
 
 tests :: TestTree
 tests = testGroup "PhoneNumber Tests"
-  [ makeCorpusTest [This PhoneNumber] corpus
-  , makeNegativeCorpusTest [This PhoneNumber] negativeCorpus
+  [ makeCorpusTest [Seal PhoneNumber] corpus
+  , makeNegativeCorpusTest [Seal PhoneNumber] negativeCorpus
   , surroundTests
   , PT.tests
   , AR.tests
@@ -36,7 +36,7 @@ tests = testGroup "PhoneNumber Tests"
 surroundTests :: TestTree
 surroundTests = testCase "Surround Tests" $
   mapM_ (analyzedFirstTest testContext testOptions .
-    withTargets [This PhoneNumber]) xs
+    withTargets [Seal PhoneNumber]) xs
   where
     xs = examples (PhoneNumberValue "06354640807")
                   [ "hey 06354640807"

--- a/tests/Duckling/Quantity/AR/Tests.hs
+++ b/tests/Duckling/Quantity/AR/Tests.hs
@@ -19,5 +19,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "AR Tests"
-  [ makeCorpusTest [This Quantity] corpus
+  [ makeCorpusTest [Seal Quantity] corpus
   ]

--- a/tests/Duckling/Quantity/EN/Tests.hs
+++ b/tests/Duckling/Quantity/EN/Tests.hs
@@ -19,6 +19,6 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "EN Tests"
-  [ makeCorpusTest [This Quantity] corpus
-  , makeCorpusTest [This Quantity] latentCorpus
+  [ makeCorpusTest [Seal Quantity] corpus
+  , makeCorpusTest [Seal Quantity] latentCorpus
   ]

--- a/tests/Duckling/Quantity/FR/Tests.hs
+++ b/tests/Duckling/Quantity/FR/Tests.hs
@@ -16,5 +16,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "FR Tests"
-  [ makeCorpusTest [This Quantity] corpus
+  [ makeCorpusTest [Seal Quantity] corpus
   ]

--- a/tests/Duckling/Quantity/HR/Tests.hs
+++ b/tests/Duckling/Quantity/HR/Tests.hs
@@ -17,5 +17,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "HR Tests"
-  [ makeCorpusTest [This Quantity] corpus
+  [ makeCorpusTest [Seal Quantity] corpus
   ]

--- a/tests/Duckling/Quantity/KM/Tests.hs
+++ b/tests/Duckling/Quantity/KM/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "KM Tests"
-  [ makeCorpusTest [This Quantity] corpus
+  [ makeCorpusTest [Seal Quantity] corpus
   ]

--- a/tests/Duckling/Quantity/KO/Tests.hs
+++ b/tests/Duckling/Quantity/KO/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "KO Tests"
-  [ makeCorpusTest [This Quantity] corpus
+  [ makeCorpusTest [Seal Quantity] corpus
   ]

--- a/tests/Duckling/Quantity/MN/Tests.hs
+++ b/tests/Duckling/Quantity/MN/Tests.hs
@@ -19,5 +19,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "MN Tests"
-  [ makeCorpusTest [This Quantity] corpus
+  [ makeCorpusTest [Seal Quantity] corpus
   ]

--- a/tests/Duckling/Quantity/NL/Tests.hs
+++ b/tests/Duckling/Quantity/NL/Tests.hs
@@ -19,5 +19,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "NL Tests"
-  [ makeCorpusTest [This Quantity] corpus
+  [ makeCorpusTest [Seal Quantity] corpus
   ]

--- a/tests/Duckling/Quantity/PT/Tests.hs
+++ b/tests/Duckling/Quantity/PT/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "PT Tests"
-  [ makeCorpusTest [This Quantity] corpus
+  [ makeCorpusTest [Seal Quantity] corpus
   ]

--- a/tests/Duckling/Quantity/RO/Tests.hs
+++ b/tests/Duckling/Quantity/RO/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "RO Tests"
-  [ makeCorpusTest [This Quantity] corpus
+  [ makeCorpusTest [Seal Quantity] corpus
   ]

--- a/tests/Duckling/Quantity/RU/Tests.hs
+++ b/tests/Duckling/Quantity/RU/Tests.hs
@@ -19,5 +19,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "RU Tests"
-  [ makeCorpusTest [This Quantity] corpus
+  [ makeCorpusTest [Seal Quantity] corpus
   ]

--- a/tests/Duckling/Quantity/ZH/Tests.hs
+++ b/tests/Duckling/Quantity/ZH/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "ZH Tests"
-  [ makeCorpusTest [This Quantity] corpus
+  [ makeCorpusTest [Seal Quantity] corpus
   ]

--- a/tests/Duckling/Temperature/AR/Tests.hs
+++ b/tests/Duckling/Temperature/AR/Tests.hs
@@ -19,5 +19,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "AR Tests"
-  [ makeCorpusTest [This Temperature] corpus
+  [ makeCorpusTest [Seal Temperature] corpus
   ]

--- a/tests/Duckling/Temperature/EN/Tests.hs
+++ b/tests/Duckling/Temperature/EN/Tests.hs
@@ -22,14 +22,14 @@ import Duckling.Types (Range(..))
 
 tests :: TestTree
 tests = testGroup "EN Tests"
-  [ makeCorpusTest [This Temperature] corpus
+  [ makeCorpusTest [Seal Temperature] corpus
   , rangeTests
   ]
 
 rangeTests :: TestTree
 rangeTests = testCase "Range Test" $
   mapM_ (analyzedRangeTest testContext testOptions
-          . withTargets [This Temperature]) xs
+          . withTargets [Seal Temperature]) xs
   where
     xs = [ ("between 40 and 30 degrees", Range 15 25 )
          , ("30 degrees degrees", Range 0 10 )

--- a/tests/Duckling/Temperature/ES/Tests.hs
+++ b/tests/Duckling/Temperature/ES/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "ES Tests"
-  [ makeCorpusTest [This Temperature] corpus
+  [ makeCorpusTest [Seal Temperature] corpus
   ]

--- a/tests/Duckling/Temperature/FR/Tests.hs
+++ b/tests/Duckling/Temperature/FR/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "FR Tests"
-  [ makeCorpusTest [This Temperature] corpus
+  [ makeCorpusTest [Seal Temperature] corpus
   ]

--- a/tests/Duckling/Temperature/GA/Tests.hs
+++ b/tests/Duckling/Temperature/GA/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "GA Tests"
-  [ makeCorpusTest [This Temperature] corpus
+  [ makeCorpusTest [Seal Temperature] corpus
   ]

--- a/tests/Duckling/Temperature/HI/Tests.hs
+++ b/tests/Duckling/Temperature/HI/Tests.hs
@@ -19,5 +19,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "HI Tests"
-  [ makeCorpusTest [This Temperature] corpus
+  [ makeCorpusTest [Seal Temperature] corpus
   ]

--- a/tests/Duckling/Temperature/HR/Tests.hs
+++ b/tests/Duckling/Temperature/HR/Tests.hs
@@ -17,5 +17,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "HR Tests"
-  [ makeCorpusTest [This Temperature] corpus
+  [ makeCorpusTest [Seal Temperature] corpus
   ]

--- a/tests/Duckling/Temperature/IT/Tests.hs
+++ b/tests/Duckling/Temperature/IT/Tests.hs
@@ -17,5 +17,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "IT Tests"
-  [ makeCorpusTest [This Temperature] corpus
+  [ makeCorpusTest [Seal Temperature] corpus
   ]

--- a/tests/Duckling/Temperature/JA/Tests.hs
+++ b/tests/Duckling/Temperature/JA/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "JA Tests"
-  [ makeCorpusTest [This Temperature] corpus
+  [ makeCorpusTest [Seal Temperature] corpus
   ]

--- a/tests/Duckling/Temperature/KM/Tests.hs
+++ b/tests/Duckling/Temperature/KM/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "KM Tests"
-  [ makeCorpusTest [This Temperature] corpus
+  [ makeCorpusTest [Seal Temperature] corpus
   ]

--- a/tests/Duckling/Temperature/KO/Tests.hs
+++ b/tests/Duckling/Temperature/KO/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "KO Tests"
-  [ makeCorpusTest [This Temperature] corpus
+  [ makeCorpusTest [Seal Temperature] corpus
   ]

--- a/tests/Duckling/Temperature/MN/Tests.hs
+++ b/tests/Duckling/Temperature/MN/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "MN Tests"
-  [ makeCorpusTest [This Temperature] corpus
+  [ makeCorpusTest [Seal Temperature] corpus
   ]

--- a/tests/Duckling/Temperature/PT/Tests.hs
+++ b/tests/Duckling/Temperature/PT/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "PT Tests"
-  [ makeCorpusTest [This Temperature] corpus
+  [ makeCorpusTest [Seal Temperature] corpus
   ]

--- a/tests/Duckling/Temperature/RO/Tests.hs
+++ b/tests/Duckling/Temperature/RO/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "RO Tests"
-  [ makeCorpusTest [This Temperature] corpus
+  [ makeCorpusTest [Seal Temperature] corpus
   ]

--- a/tests/Duckling/Temperature/TR/Tests.hs
+++ b/tests/Duckling/Temperature/TR/Tests.hs
@@ -19,5 +19,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "TR Tests"
-  [ makeCorpusTest [This Temperature] corpus
+  [ makeCorpusTest [Seal Temperature] corpus
   ]

--- a/tests/Duckling/Temperature/ZH/Tests.hs
+++ b/tests/Duckling/Temperature/ZH/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "ZH Tests"
-  [ makeCorpusTest [This Temperature] corpus
+  [ makeCorpusTest [Seal Temperature] corpus
   ]

--- a/tests/Duckling/Testing/Asserts.hs
+++ b/tests/Duckling/Testing/Asserts.hs
@@ -40,20 +40,20 @@ newtype ExampleInput = ExampleInput Text
 instance Show ExampleInput where
   show (ExampleInput input) = "\"" ++ Text.unpack input ++ "\""
 
-withTargets :: [Some Dimension] -> (Text, a) -> (Text, [Some Dimension], a)
+withTargets :: [Seal Dimension] -> (Text, a) -> (Text, [Seal Dimension], a)
 withTargets targets (input, expected) = (input, targets, expected)
 
-analyzedTargetTest :: Context -> Options -> (Text, Some Dimension) -> IO ()
+analyzedTargetTest :: Context -> Options -> (Text, Seal Dimension) -> IO ()
 analyzedTargetTest context options (input, target) =
   assertBool msg $ all (== target) dimensions
   where
     msg = "analyze " ++ show (ExampleInput input, [target])
           ++ "dimensions = " ++ show dimensions
     dimensions = flip map (analyze input context options $ HashSet.singleton target) $
-      \(Resolved{node=Node{token=Token dimension _}}) -> This dimension
+      \(Resolved{node=Node{token=Token dimension _}}) -> Seal dimension
 
 analyzedFirstTest :: Context -> Options ->
-  (Text, [Some Dimension], TestPredicate) -> IO ()
+  (Text, [Seal Dimension], TestPredicate) -> IO ()
 analyzedFirstTest context options (input, targets, predicate) =
   case tokens of
     [] -> assertFailure
@@ -65,7 +65,7 @@ analyzedFirstTest context options (input, targets, predicate) =
       tokens = analyze input context options $ HashSet.fromList targets
 
 analyzedAmbiguousTest :: Context -> Options ->
-  (Text, [Some Dimension], [TestPredicate]) -> IO ()
+  (Text, [Seal Dimension], [TestPredicate]) -> IO ()
 analyzedAmbiguousTest context options (input, targets, predicates) =
   case tokens of
     [] -> assertFailure
@@ -75,7 +75,7 @@ analyzedAmbiguousTest context options (input, targets, predicates) =
     where
       tokens = analyze input context options $ HashSet.fromList targets
 
-makeCorpusTest :: [Some Dimension] -> Corpus -> TestTree
+makeCorpusTest :: [Seal Dimension] -> Corpus -> TestTree
 makeCorpusTest targets (context, options, xs) = testCase "Corpus Tests" $
   mapM_ check xs
   where
@@ -101,12 +101,12 @@ makeCorpusTest targets (context, options, xs) = testCase "Corpus Tests" $
           ++ " different ambiguous parses on " ++ show (ExampleInput input)
 
 
-makeNegativeCorpusTest :: [Some Dimension] -> NegativeCorpus -> TestTree
+makeNegativeCorpusTest :: [Seal Dimension] -> NegativeCorpus -> TestTree
 makeNegativeCorpusTest targets (context, options, xs) =
   testCase "Negative Corpus Tests"
   $ mapM_ (analyzedNothingTest context options . (, targets)) xs
 
-analyzedRangeTest :: Context -> Options -> (Text, [Some Dimension], Range)
+analyzedRangeTest :: Context -> Options -> (Text, [Seal Dimension], Range)
   -> IO ()
 analyzedRangeTest context options  (input, targets, expRange) = case tokens of
   [] -> assertFailure $ "empty result on " ++ show (ExampleInput input)
@@ -118,11 +118,11 @@ analyzedRangeTest context options  (input, targets, expRange) = case tokens of
   where
     tokens = analyze input context options $ HashSet.fromList targets
 
-analyzedNothingTest :: Context -> Options -> (Text, [Some Dimension]) -> IO ()
+analyzedNothingTest :: Context -> Options -> (Text, [Seal Dimension]) -> IO ()
 analyzedNothingTest context options (input, targets) =
   analyzedNTest context options (input, targets, 0)
 
-analyzedNTest :: Context -> Options -> (Text, [Some Dimension], Int) -> IO ()
+analyzedNTest :: Context -> Options -> (Text, [Seal Dimension], Int) -> IO ()
 analyzedNTest context options (input, targets, n) =
   assertBool msg . (== n) $ length tokens
   where

--- a/tests/Duckling/Time/AR/Tests.hs
+++ b/tests/Duckling/Time/AR/Tests.hs
@@ -18,6 +18,6 @@ import Duckling.Time.AR.Corpus
 
 tests :: TestTree
 tests = testGroup "AR Tests"
-  [ makeCorpusTest [This Time] corpus
-  , makeNegativeCorpusTest [This Time] negativeCorpus
+  [ makeCorpusTest [Seal Time] corpus
+  , makeNegativeCorpusTest [Seal Time] negativeCorpus
   ]

--- a/tests/Duckling/Time/BG/Tests.hs
+++ b/tests/Duckling/Time/BG/Tests.hs
@@ -30,6 +30,6 @@ import Duckling.Types (Range(..))
 
 tests :: TestTree
 tests = testGroup "BG Tests"
-  [ makeCorpusTest [This Time] corpus
-  , makeNegativeCorpusTest [This Time] negativeCorpus
+  [ makeCorpusTest [Seal Time] corpus
+  , makeNegativeCorpusTest [Seal Time] negativeCorpus
   ]

--- a/tests/Duckling/Time/DA/Tests.hs
+++ b/tests/Duckling/Time/DA/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Time.DA.Corpus
 
 tests :: TestTree
 tests = testGroup "DA Tests"
-  [ makeCorpusTest [This Time] corpus
+  [ makeCorpusTest [Seal Time] corpus
   ]

--- a/tests/Duckling/Time/DE/Tests.hs
+++ b/tests/Duckling/Time/DE/Tests.hs
@@ -23,15 +23,15 @@ import Duckling.Types (Range(..))
 
 tests :: TestTree
 tests = testGroup "DE Tests"
-  [ makeCorpusTest [This Time] corpus
-  , makeNegativeCorpusTest [This Time] negativeCorpus
+  [ makeCorpusTest [Seal Time] corpus
+  , makeNegativeCorpusTest [Seal Time] negativeCorpus
   , rangeTests
   ]
 
 rangeTests :: TestTree
 rangeTests = testCase "Range Test" $
   mapM_ (analyzedRangeTest (testContext{locale = makeLocale DE Nothing})
-         testOptions . withTargets [This Time]) xs
+         testOptions . withTargets [Seal Time]) xs
   where
     xs = [ ("Wir treffen uns am 17 Uhr am KiLa.", Range 16 25)
          ]

--- a/tests/Duckling/Time/EL/Tests.hs
+++ b/tests/Duckling/Time/EL/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Time.EL.Corpus
 
 tests :: TestTree
 tests = testGroup "EL Tests"
-  [ makeCorpusTest [This Time] corpus
+  [ makeCorpusTest [Seal Time] corpus
   ]

--- a/tests/Duckling/Time/EN/Tests.hs
+++ b/tests/Duckling/Time/EN/Tests.hs
@@ -44,66 +44,66 @@ import qualified Duckling.Time.EN.ZA.Corpus as ZA
 
 tests :: TestTree
 tests = testGroup "EN Tests"
-  [ makeCorpusTest [This Time] defaultCorpus
-  , makeNegativeCorpusTest [This Time] negativeCorpus
-  , makeCorpusTest [This Time] diffCorpus
+  [ makeCorpusTest [Seal Time] defaultCorpus
+  , makeNegativeCorpusTest [Seal Time] negativeCorpus
+  , makeCorpusTest [Seal Time] diffCorpus
   , exactSecondTests
   , valuesTest
   , intersectTests
   , rangeTests
   , localeTests
-  , makeCorpusTest [This Time] latentCorpus
+  , makeCorpusTest [Seal Time] latentCorpus
   ]
 
 localeTests :: TestTree
 localeTests = testGroup "Locale Tests"
   [ testGroup "EN_AU Tests"
-    [ makeCorpusTest [This Time] $ withLocale corpus localeAU AU.allExamples
-    , makeNegativeCorpusTest [This Time] $ withLocale negativeCorpus localeAU []
+    [ makeCorpusTest [Seal Time] $ withLocale corpus localeAU AU.allExamples
+    , makeNegativeCorpusTest [Seal Time] $ withLocale negativeCorpus localeAU []
     ]
   , testGroup "EN_BZ Tests"
-    [ makeCorpusTest [This Time] $ withLocale corpus localeBZ BZ.allExamples
-    , makeNegativeCorpusTest [This Time] $ withLocale negativeCorpus localeBZ []
+    [ makeCorpusTest [Seal Time] $ withLocale corpus localeBZ BZ.allExamples
+    , makeNegativeCorpusTest [Seal Time] $ withLocale negativeCorpus localeBZ []
     ]
   , testGroup "EN_CA Tests"
-    [ makeCorpusTest [This Time] $ withLocale corpus localeCA CA.allExamples
-    , makeNegativeCorpusTest [This Time] $ withLocale negativeCorpus localeCA []
+    [ makeCorpusTest [Seal Time] $ withLocale corpus localeCA CA.allExamples
+    , makeNegativeCorpusTest [Seal Time] $ withLocale negativeCorpus localeCA []
     ]
   , testGroup "EN_GB Tests"
-    [ makeCorpusTest [This Time] $ withLocale corpus localeGB GB.allExamples
-    , makeNegativeCorpusTest [This Time] $ withLocale negativeCorpus localeGB []
+    [ makeCorpusTest [Seal Time] $ withLocale corpus localeGB GB.allExamples
+    , makeNegativeCorpusTest [Seal Time] $ withLocale negativeCorpus localeGB []
     ]
   , testGroup "EN_IE Tests"
-    [ makeCorpusTest [This Time] $ withLocale corpus localeIE IE.allExamples
-    , makeNegativeCorpusTest [This Time] $ withLocale negativeCorpus localeIE []
+    [ makeCorpusTest [Seal Time] $ withLocale corpus localeIE IE.allExamples
+    , makeNegativeCorpusTest [Seal Time] $ withLocale negativeCorpus localeIE []
     ]
   , testGroup "EN_IN Tests"
-    [ makeCorpusTest [This Time] $ withLocale corpus localeIN IN.allExamples
-    , makeNegativeCorpusTest [This Time] $ withLocale negativeCorpus localeIN []
+    [ makeCorpusTest [Seal Time] $ withLocale corpus localeIN IN.allExamples
+    , makeNegativeCorpusTest [Seal Time] $ withLocale negativeCorpus localeIN []
     ]
   , testGroup "EN_JM Tests"
-    [ makeCorpusTest [This Time] $ withLocale corpus localeJM JM.allExamples
-    , makeNegativeCorpusTest [This Time] $ withLocale negativeCorpus localeJM []
+    [ makeCorpusTest [Seal Time] $ withLocale corpus localeJM JM.allExamples
+    , makeNegativeCorpusTest [Seal Time] $ withLocale negativeCorpus localeJM []
     ]
   , testGroup "EN_NZ Tests"
-    [ makeCorpusTest [This Time] $ withLocale corpus localeNZ NZ.allExamples
-    , makeNegativeCorpusTest [This Time] $ withLocale negativeCorpus localeNZ []
+    [ makeCorpusTest [Seal Time] $ withLocale corpus localeNZ NZ.allExamples
+    , makeNegativeCorpusTest [Seal Time] $ withLocale negativeCorpus localeNZ []
     ]
   , testGroup "EN_PH Tests"
-    [ makeCorpusTest [This Time] $ withLocale corpus localePH PH.allExamples
-    , makeNegativeCorpusTest [This Time] $ withLocale negativeCorpus localePH []
+    [ makeCorpusTest [Seal Time] $ withLocale corpus localePH PH.allExamples
+    , makeNegativeCorpusTest [Seal Time] $ withLocale negativeCorpus localePH []
     ]
   , testGroup "EN_TT Tests"
-    [ makeCorpusTest [This Time] $ withLocale corpus localeTT TT.allExamples
-    , makeNegativeCorpusTest [This Time] $ withLocale negativeCorpus localeTT []
+    [ makeCorpusTest [Seal Time] $ withLocale corpus localeTT TT.allExamples
+    , makeNegativeCorpusTest [Seal Time] $ withLocale negativeCorpus localeTT []
     ]
   , testGroup "EN_US Tests"
-    [ makeCorpusTest [This Time] $ withLocale corpus localeUS US.allExamples
-    , makeNegativeCorpusTest [This Time] $ withLocale negativeCorpus localeUS []
+    [ makeCorpusTest [Seal Time] $ withLocale corpus localeUS US.allExamples
+    , makeNegativeCorpusTest [Seal Time] $ withLocale negativeCorpus localeUS []
     ]
   , testGroup "EN_ZA Tests"
-    [ makeCorpusTest [This Time] $ withLocale corpus localeZA ZA.allExamples
-    , makeNegativeCorpusTest [This Time] $ withLocale negativeCorpus localeZA []
+    [ makeCorpusTest [Seal Time] $ withLocale corpus localeZA ZA.allExamples
+    , makeNegativeCorpusTest [Seal Time] $ withLocale negativeCorpus localeZA []
     ]
   ]
   where
@@ -122,7 +122,7 @@ localeTests = testGroup "Locale Tests"
 
 exactSecondTests :: TestTree
 exactSecondTests = testCase "Exact Second Tests" $
-  mapM_ (analyzedFirstTest context testOptions . withTargets [This Time]) xs
+  mapM_ (analyzedFirstTest context testOptions . withTargets [Seal Time]) xs
   where
     context = testContext {referenceTime = refTime (2016, 12, 6, 13, 21, 42) 1}
     xs = concat
@@ -141,7 +141,7 @@ exactSecondTests = testCase "Exact Second Tests" $
 
 valuesTest :: TestTree
 valuesTest = testCase "Values Test" $
-  mapM_ (analyzedFirstTest testContext testOptions . withTargets [This Time]) xs
+  mapM_ (analyzedFirstTest testContext testOptions . withTargets [Seal Time]) xs
   where
     xs = examplesCustom (parserCheck 1 parseValuesSize)
                         [ "now"
@@ -155,7 +155,7 @@ valuesTest = testCase "Values Test" $
 
 intersectTests :: TestTree
 intersectTests = testCase "Intersect Test" $
-  mapM_ (analyzedNTest testContext testOptions . withTargets [This Time]) xs
+  mapM_ (analyzedNTest testContext testOptions . withTargets [Seal Time]) xs
   where
     xs = [ ("tomorrow July", 2)
          , ("Mar tonight", 2)
@@ -164,7 +164,7 @@ intersectTests = testCase "Intersect Test" $
 
 rangeTests :: TestTree
 rangeTests = testCase "Range Test" $
-  mapM_ (analyzedRangeTest testContext testOptions . withTargets [This Time]) xs
+  mapM_ (analyzedRangeTest testContext testOptions . withTargets [Seal Time]) xs
   where
     xs = [ ("at 615.", Range 0 6) -- make sure ruleHHMMLatent allows this
          , ("last in 2'", Range 5 10) -- ruleLastTime too eager

--- a/tests/Duckling/Time/ES/Tests.hs
+++ b/tests/Duckling/Time/ES/Tests.hs
@@ -18,6 +18,6 @@ import Duckling.Time.ES.Corpus
 
 tests :: TestTree
 tests = testGroup "ES Tests"
-  [ makeCorpusTest [This Time] corpus
-    , makeCorpusTest [This Time] latentCorpus
+  [ makeCorpusTest [Seal Time] corpus
+    , makeCorpusTest [Seal Time] latentCorpus
   ]

--- a/tests/Duckling/Time/FR/Tests.hs
+++ b/tests/Duckling/Time/FR/Tests.hs
@@ -18,6 +18,6 @@ import Duckling.Time.FR.Corpus
 
 tests :: TestTree
 tests = testGroup "FR Tests"
-  [ makeCorpusTest [This Time] corpus
-  , makeNegativeCorpusTest [This Time] negativeCorpus
+  [ makeCorpusTest [Seal Time] corpus
+  , makeNegativeCorpusTest [Seal Time] negativeCorpus
   ]

--- a/tests/Duckling/Time/GA/Tests.hs
+++ b/tests/Duckling/Time/GA/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Time.GA.Corpus
 
 tests :: TestTree
 tests = testGroup "GA Tests"
-  [ makeCorpusTest [This Time] corpus
+  [ makeCorpusTest [Seal Time] corpus
   ]

--- a/tests/Duckling/Time/HE/Tests.hs
+++ b/tests/Duckling/Time/HE/Tests.hs
@@ -17,5 +17,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "HE Tests"
-  [ makeCorpusTest [This Time] corpus
+  [ makeCorpusTest [Seal Time] corpus
   ]

--- a/tests/Duckling/Time/HR/Tests.hs
+++ b/tests/Duckling/Time/HR/Tests.hs
@@ -17,5 +17,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "HR Tests"
-  [ makeCorpusTest [This Time] corpus
+  [ makeCorpusTest [Seal Time] corpus
   ]

--- a/tests/Duckling/Time/HU/Tests.hs
+++ b/tests/Duckling/Time/HU/Tests.hs
@@ -17,5 +17,5 @@ import Duckling.Time.HU.Corpus
 
 tests :: TestTree
 tests = testGroup "HU Tests"
-  [ makeCorpusTest [This Time] corpus
+  [ makeCorpusTest [Seal Time] corpus
   ]

--- a/tests/Duckling/Time/IT/Tests.hs
+++ b/tests/Duckling/Time/IT/Tests.hs
@@ -18,6 +18,6 @@ import Duckling.Time.IT.Corpus
 
 tests :: TestTree
 tests = testGroup "IT Tests"
-  [ makeCorpusTest [This Time] corpus
-  , makeNegativeCorpusTest [This Time] negativeCorpus
+  [ makeCorpusTest [Seal Time] corpus
+  , makeNegativeCorpusTest [Seal Time] negativeCorpus
   ]

--- a/tests/Duckling/Time/KA/Tests.hs
+++ b/tests/Duckling/Time/KA/Tests.hs
@@ -19,6 +19,6 @@ import Duckling.Time.KA.Corpus
 
 tests :: TestTree
 tests = testGroup "KA Tests"
-  [ makeCorpusTest [This Time] corpus
-  , makeCorpusTest [This Time] latentCorpus
+  [ makeCorpusTest [Seal Time] corpus
+  , makeCorpusTest [Seal Time] latentCorpus
   ]

--- a/tests/Duckling/Time/KO/Tests.hs
+++ b/tests/Duckling/Time/KO/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Time.KO.Corpus
 
 tests :: TestTree
 tests = testGroup "KO Tests"
-  [ makeCorpusTest [This Time] corpus
+  [ makeCorpusTest [Seal Time] corpus
   ]

--- a/tests/Duckling/Time/NB/Tests.hs
+++ b/tests/Duckling/Time/NB/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Time.NB.Corpus
 
 tests :: TestTree
 tests = testGroup "NB Tests"
-  [ makeCorpusTest [This Time] corpus
+  [ makeCorpusTest [Seal Time] corpus
   ]

--- a/tests/Duckling/Time/NL/Tests.hs
+++ b/tests/Duckling/Time/NL/Tests.hs
@@ -22,17 +22,17 @@ import qualified Duckling.Time.NL.BE.Corpus as BE
 
 tests :: TestTree
 tests = testGroup "NL Tests"
-  [ makeCorpusTest [This Time] corpus
-  , makeCorpusTest [This Time] latentCorpus
-  , makeNegativeCorpusTest [This Time] negativeCorpus
+  [ makeCorpusTest [Seal Time] corpus
+  , makeCorpusTest [Seal Time] latentCorpus
+  , makeNegativeCorpusTest [Seal Time] negativeCorpus
   , localeTests
   ]
 
 localeTests :: TestTree
 localeTests = testGroup "Locale Tests"
   [ testGroup "NL_BE Tests"
-    [ makeCorpusTest [This Time] $ withLocale corpus localeBE BE.allExamples
-    , makeNegativeCorpusTest [This Time] $ withLocale negativeCorpus localeBE []
+    [ makeCorpusTest [Seal Time] $ withLocale corpus localeBE BE.allExamples
+    , makeNegativeCorpusTest [Seal Time] $ withLocale negativeCorpus localeBE []
     ]
   ]
   where

--- a/tests/Duckling/Time/PL/Tests.hs
+++ b/tests/Duckling/Time/PL/Tests.hs
@@ -18,6 +18,6 @@ import Duckling.Time.PL.Corpus
 
 tests :: TestTree
 tests = testGroup "PL Tests"
-  [ makeCorpusTest [This Time] corpus
-  , makeNegativeCorpusTest [This Time] negativeCorpus
+  [ makeCorpusTest [Seal Time] corpus
+  , makeNegativeCorpusTest [Seal Time] negativeCorpus
   ]

--- a/tests/Duckling/Time/PT/Tests.hs
+++ b/tests/Duckling/Time/PT/Tests.hs
@@ -18,6 +18,6 @@ import Duckling.Time.PT.Corpus
 
 tests :: TestTree
 tests = testGroup "PT Tests"
-  [ makeCorpusTest [This Time] corpus
-  , makeNegativeCorpusTest [This Time] negativeCorpus
+  [ makeCorpusTest [Seal Time] corpus
+  , makeNegativeCorpusTest [Seal Time] negativeCorpus
   ]

--- a/tests/Duckling/Time/RO/Tests.hs
+++ b/tests/Duckling/Time/RO/Tests.hs
@@ -18,6 +18,6 @@ import Duckling.Time.RO.Corpus
 
 tests :: TestTree
 tests = testGroup "RO Tests"
-  [ makeCorpusTest [This Time] corpus
-  , makeNegativeCorpusTest [This Time] negativeCorpus
+  [ makeCorpusTest [Seal Time] corpus
+  , makeNegativeCorpusTest [Seal Time] negativeCorpus
   ]

--- a/tests/Duckling/Time/SV/Tests.hs
+++ b/tests/Duckling/Time/SV/Tests.hs
@@ -29,7 +29,7 @@ import Duckling.TimeGrain.Types (Grain(..))
 
 tests :: TestTree
 tests = testGroup "SV Tests"
-  [ makeCorpusTest [This Time] corpus
+  [ makeCorpusTest [Seal Time] corpus
   , ambiguousTests
   ]
 
@@ -43,7 +43,7 @@ ambiguousTests = testCase "Ambiguous Tests" $ mapM_ check xs
                   [ "i morgonen"
                   ]
     ctx = testContext {locale = makeLocale SV Nothing}
-    dims = HashSet.singleton $ This Time
+    dims = HashSet.singleton $ Seal Time
     check :: Example -> IO ()
     check (input, predicate) = case analyze input ctx testOptions dims of
       [] -> assertFailure $ "empty result on " ++ show input

--- a/tests/Duckling/Time/Tests.hs
+++ b/tests/Duckling/Time/Tests.hs
@@ -80,7 +80,7 @@ tests = testGroup "Time Tests"
 
 timeFormatTest :: TestTree
 timeFormatTest = testCase "Format Test" $
-  mapM_ (analyzedFirstTest testContext testOptions . withTargets [This Time]) xs
+  mapM_ (analyzedFirstTest testContext testOptions . withTargets [Seal Time]) xs
   where
     xs = examplesCustom (parserCheck expected parseValue) ["now"]
     expected = "2013-02-12T04:30:00.000-02:00"

--- a/tests/Duckling/Time/UK/Tests.hs
+++ b/tests/Duckling/Time/UK/Tests.hs
@@ -23,6 +23,6 @@ import Duckling.Types (Range(..))
 
 tests :: TestTree
 tests = testGroup "UK Tests"
-  [ makeCorpusTest [This Time] corpus
-  , makeNegativeCorpusTest [This Time] negativeCorpus
+  [ makeCorpusTest [Seal Time] corpus
+  , makeNegativeCorpusTest [Seal Time] negativeCorpus
   ]

--- a/tests/Duckling/Time/VI/Tests.hs
+++ b/tests/Duckling/Time/VI/Tests.hs
@@ -17,6 +17,6 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "VI Tests"
-  [ makeCorpusTest [This Time] corpus
-  , makeNegativeCorpusTest [This Time] negativeCorpus
+  [ makeCorpusTest [Seal Time] corpus
+  , makeNegativeCorpusTest [Seal Time] negativeCorpus
   ]

--- a/tests/Duckling/Time/ZH/Tests.hs
+++ b/tests/Duckling/Time/ZH/Tests.hs
@@ -25,23 +25,23 @@ import qualified Duckling.Time.ZH.TW.Corpus as TW
 
 tests :: TestTree
 tests = testGroup "ZH Tests"
-  [ makeCorpusTest [This Time] defaultCorpus
+  [ makeCorpusTest [Seal Time] defaultCorpus
   , localeTests
   ]
 
 localeTests :: TestTree
 localeTests = testGroup "Locale Tests"
   [ testGroup "ZH_CN Tests"
-    [ makeCorpusTest [This Time] $ withLocale corpus localeCN CN.allExamples
+    [ makeCorpusTest [Seal Time] $ withLocale corpus localeCN CN.allExamples
     ]
   , testGroup "ZH_HK Tests"
-    [ makeCorpusTest [This Time] $ withLocale corpus localeHK HK.allExamples
+    [ makeCorpusTest [Seal Time] $ withLocale corpus localeHK HK.allExamples
     ]
   , testGroup "ZH_MO Tests"
-    [ makeCorpusTest [This Time] $ withLocale corpus localeMO MO.allExamples
+    [ makeCorpusTest [Seal Time] $ withLocale corpus localeMO MO.allExamples
     ]
   , testGroup "ZH_TW Tests"
-    [ makeCorpusTest [This Time] $ withLocale corpus localeTW TW.allExamples
+    [ makeCorpusTest [Seal Time] $ withLocale corpus localeTW TW.allExamples
     ]
   ]
   where

--- a/tests/Duckling/Url/Tests.hs
+++ b/tests/Duckling/Url/Tests.hs
@@ -24,14 +24,14 @@ import Duckling.Url.Types
 
 tests :: TestTree
 tests = testGroup "Url Tests"
-  [ makeCorpusTest [This Url] corpus
-  , makeNegativeCorpusTest [This Url] negativeCorpus
+  [ makeCorpusTest [Seal Url] corpus
+  , makeNegativeCorpusTest [Seal Url] negativeCorpus
   , surroundTests
   ]
 
 surroundTests :: TestTree
 surroundTests = testCase "Surround Tests" $
-  mapM_ (analyzedFirstTest testContext testOptions . withTargets [This Url]) xs
+  mapM_ (analyzedFirstTest testContext testOptions . withTargets [Seal Url]) xs
   where
     xs = examples (UrlData "www.lets-try-this-one.co.uk/episode-7" "lets-try-this-one.co.uk")
                   [ "phishing link: www.lets-try-this-one.co.uk/episode-7  If you want my job"

--- a/tests/Duckling/Volume/AR/Tests.hs
+++ b/tests/Duckling/Volume/AR/Tests.hs
@@ -19,5 +19,5 @@ import Duckling.Volume.AR.Corpus
 
 tests :: TestTree
 tests = testGroup "AR Tests"
-  [ makeCorpusTest [This Volume] corpus
+  [ makeCorpusTest [Seal Volume] corpus
   ]

--- a/tests/Duckling/Volume/DE/Tests.hs
+++ b/tests/Duckling/Volume/DE/Tests.hs
@@ -19,5 +19,5 @@ import Duckling.Volume.DE.Corpus
 
 tests :: TestTree
 tests = testGroup "DE Tests"
-  [ makeCorpusTest [This Volume] corpus
+  [ makeCorpusTest [Seal Volume] corpus
   ]

--- a/tests/Duckling/Volume/EN/Tests.hs
+++ b/tests/Duckling/Volume/EN/Tests.hs
@@ -19,5 +19,5 @@ import Duckling.Volume.EN.Corpus
 
 tests :: TestTree
 tests = testGroup "EN Tests"
-  [ makeCorpusTest [This Volume] corpus
+  [ makeCorpusTest [Seal Volume] corpus
   ]

--- a/tests/Duckling/Volume/ES/Tests.hs
+++ b/tests/Duckling/Volume/ES/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Volume.ES.Corpus
 
 tests :: TestTree
 tests = testGroup "ES Tests"
-  [ makeCorpusTest [This Volume] corpus
+  [ makeCorpusTest [Seal Volume] corpus
   ]

--- a/tests/Duckling/Volume/FR/Tests.hs
+++ b/tests/Duckling/Volume/FR/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Volume.FR.Corpus
 
 tests :: TestTree
 tests = testGroup "FR Tests"
-  [ makeCorpusTest [This Volume] corpus
+  [ makeCorpusTest [Seal Volume] corpus
   ]

--- a/tests/Duckling/Volume/GA/Tests.hs
+++ b/tests/Duckling/Volume/GA/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Volume.GA.Corpus
 
 tests :: TestTree
 tests = testGroup "GA Tests"
-  [ makeCorpusTest [This Volume] corpus
+  [ makeCorpusTest [Seal Volume] corpus
   ]

--- a/tests/Duckling/Volume/HR/Tests.hs
+++ b/tests/Duckling/Volume/HR/Tests.hs
@@ -17,5 +17,5 @@ import Duckling.Testing.Asserts
 
 tests :: TestTree
 tests = testGroup "HR Tests"
-  [ makeCorpusTest [This Volume] corpus
+  [ makeCorpusTest [Seal Volume] corpus
   ]

--- a/tests/Duckling/Volume/IT/Tests.hs
+++ b/tests/Duckling/Volume/IT/Tests.hs
@@ -17,5 +17,5 @@ import Duckling.Volume.IT.Corpus
 
 tests :: TestTree
 tests = testGroup "IT Tests"
-  [ makeCorpusTest [This Volume] corpus
+  [ makeCorpusTest [Seal Volume] corpus
   ]

--- a/tests/Duckling/Volume/KM/Tests.hs
+++ b/tests/Duckling/Volume/KM/Tests.hs
@@ -19,5 +19,5 @@ import Duckling.Volume.KM.Corpus
 
 tests :: TestTree
 tests = testGroup "KM Tests"
-  [ makeCorpusTest [This Volume] corpus
+  [ makeCorpusTest [Seal Volume] corpus
   ]

--- a/tests/Duckling/Volume/KO/Tests.hs
+++ b/tests/Duckling/Volume/KO/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Volume.KO.Corpus
 
 tests :: TestTree
 tests = testGroup "KO Tests"
-  [ makeCorpusTest [This Volume] corpus
+  [ makeCorpusTest [Seal Volume] corpus
   ]

--- a/tests/Duckling/Volume/MN/Tests.hs
+++ b/tests/Duckling/Volume/MN/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Volume.MN.Corpus
 
 tests :: TestTree
 tests = testGroup "MN Tests"
-  [ makeCorpusTest [This Volume] corpus
+  [ makeCorpusTest [Seal Volume] corpus
   ]

--- a/tests/Duckling/Volume/NL/Tests.hs
+++ b/tests/Duckling/Volume/NL/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Volume.NL.Corpus
 
 tests :: TestTree
 tests = testGroup "NL Tests"
-  [ makeCorpusTest [This Volume] corpus
+  [ makeCorpusTest [Seal Volume] corpus
   ]

--- a/tests/Duckling/Volume/PT/Tests.hs
+++ b/tests/Duckling/Volume/PT/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Volume.PT.Corpus
 
 tests :: TestTree
 tests = testGroup "PT Tests"
-  [ makeCorpusTest [This Volume] corpus
+  [ makeCorpusTest [Seal Volume] corpus
   ]

--- a/tests/Duckling/Volume/RO/Tests.hs
+++ b/tests/Duckling/Volume/RO/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Volume.RO.Corpus
 
 tests :: TestTree
 tests = testGroup "RO Tests"
-  [ makeCorpusTest [This Volume] corpus
+  [ makeCorpusTest [Seal Volume] corpus
   ]

--- a/tests/Duckling/Volume/RU/Tests.hs
+++ b/tests/Duckling/Volume/RU/Tests.hs
@@ -18,5 +18,5 @@ import Duckling.Volume.RU.Corpus
 
 tests :: TestTree
 tests = testGroup "RU Tests"
-  [ makeCorpusTest [This Volume] corpus
+  [ makeCorpusTest [Seal Volume] corpus
   ]

--- a/tests/Duckling/Volume/TR/Tests.hs
+++ b/tests/Duckling/Volume/TR/Tests.hs
@@ -19,5 +19,5 @@ import Duckling.Volume.TR.Corpus
 
 tests :: TestTree
 tests = testGroup "TR Tests"
-  [ makeCorpusTest [This Volume] corpus
+  [ makeCorpusTest [Seal Volume] corpus
   ]


### PR DESCRIPTION
Summary: In recent versions of Data.Some the name of the constructor, `This` has changed name to `Some`. This has become rather problematic for us to migrate so we're just going to remove the dependency. The meat of this diff is adding the type `Seal` to `Duckling.Types`. That type replaces `Some`.

Reviewed By: pepeiborra

Differential Revision: D23929459

