### PR TITLE
Quantity/EN: Support k.g k.g.

### DIFF
--- a/Duckling/Quantity/EN/Corpus.hs
+++ b/Duckling/Quantity/EN/Corpus.hs
@@ -47,12 +47,14 @@ allExamples = concat
   , examples (simple Gram 2 Nothing)
              [ "2 grams"
              , "0.002 kg"
+             , "2 g."
              , "2/1000 kilograms"
              , "2000 milligrams"
              ]
   , examples (simple Gram 1000 Nothing)
              [ "a kilogram"
              , "a kg"
+             , "1 k.g."
              ]
   , examples (simple Pound 1 Nothing)
              [ "a Pound"

--- a/Duckling/Quantity/EN/Rules.hs
+++ b/Duckling/Quantity/EN/Rules.hs
@@ -33,7 +33,7 @@ import qualified Duckling.Quantity.Types as TQuantity
 quantities :: [(Text, String, TQuantity.Unit)]
 quantities =
   [ ("<quantity> cups", "(cups?)", TQuantity.Cup)
-  , ("<quantity> grams", "(((m(illi)?)|(k(ilo)?))?g(ram)?s?)", TQuantity.Gram)
+  , ("<quantity> grams", "(((m(illi)?[.]?)|(k(ilo)?)[.]?)?g(ram)?s?[.]?)", TQuantity.Gram)
   , ("<quantity> lb", "((lb|pound)s?)", TQuantity.Pound)
   , ("<quantity> oz", "((ounces?)|oz)", TQuantity.Ounce)
   ]
@@ -44,10 +44,18 @@ opsMap = HashMap.fromList
   , ( "milligrams", (/ 1000))
   , ( "mg"        , (/ 1000))
   , ( "mgs"       , (/ 1000))
+  , ( "m.g"        , (/ 1000))
+  , ( "m.gs"       , (/ 1000))
+  , ( "m.g."        , (/ 1000))
+  , ( "m.g.s"       , (/ 1000))
   , ( "kilogram"  , (* 1000))
   , ( "kilograms" , (* 1000))
   , ( "kg"        , (* 1000))
   , ( "kgs"       , (* 1000))
+  , ( "k.g"        , (* 1000))
+  , ( "k.gs"        , (* 1000))
+  , ( "k.g."        , (* 1000))
+  , ( "k.g.s"        , (* 1000))
   ]
 
 ruleNumeralQuantities :: [Rule]


### PR DESCRIPTION
Adding . in between kilogram units used to be extracted as a Numeral
instead of Quantity.