### PR TITLE
Typo correction

### DIFF
--- a/Duckling/Duration/TR/Rules.hs
+++ b/Duckling/Duration/TR/Rules.hs
@@ -43,7 +43,7 @@ ruleDurationHalfAnHour = Rule
 ruleDurationThreeQuartersOfAnHour :: Rule
 ruleDurationThreeQuartersOfAnHour = Rule
   { name = "three-quarters of an hour"
-  , pattern = [regex "(3/4\\s?sa(at)?|üçe \231eyrek sa(at)?)"]
+  , pattern = [regex "(3/4\\s?sa(at)?|üç \231eyrek sa(at)?)"]
   , prod = \_ -> Just . Token Duration $ duration TG.Minute 45
   }
 

--- a/Duckling/Duration/TR/Rules.hs
+++ b/Duckling/Duration/TR/Rules.hs
@@ -89,7 +89,7 @@ ruleDurationAndHalfHour = Rule
   { name = "<integer> and an half hour"
   , pattern =
     [ Predicate isNatural
-    , regex "buçeuk sa(at)?"
+    , regex "buçuk sa(at)?"
     ]
   , prod = \tokens -> case tokens of
       (Token Numeral NumeralData{TNumeral.value = v}:_) ->


### PR DESCRIPTION
This commit includes typo correction for `half` and `three` equivelant in Turkish