### PR TITLE
Add more variants of egp to EN and AR AmountOfMoney dimension

### DIFF
--- a/Duckling/AmountOfMoney/AR/Corpus.hs
+++ b/Duckling/AmountOfMoney/AR/Corpus.hs
@@ -86,6 +86,8 @@ allExamples = concat
              [ "42 EGP"
              , "42 جنيه مصري"
              , "42 جنيهات مصريه"
+             , "42 ج.م"
+             , "42 ج.م."
              ]
   , examples (simple QAR 42)
              [ "42 QAR"

--- a/Duckling/AmountOfMoney/AR/Rules.hs
+++ b/Duckling/AmountOfMoney/AR/Rules.hs
@@ -51,6 +51,15 @@ rulePounds = Rule
   , prod = \_ -> Just . Token AmountOfMoney $ currencyOnly Pound
   }
 
+ruleEgpAbrreviation :: Rule
+ruleEgpAbrreviation = Rule
+  { name = "EGP abbreviation"
+  , pattern =
+    [ regex "ج[.]م[.]?"
+    ]
+  , prod = \_ -> Just . Token AmountOfMoney $ currencyOnly EGP
+  }
+
 ruleDinars :: Rule
 ruleDinars = Rule
   { name = "dinars"
@@ -390,6 +399,7 @@ rules =
   [ ruleUnitAmount
   , ruleCent
   , rulePounds
+  , ruleEgpAbrreviation
   , ruleDinars
   , ruleDirhams
   , ruleRiyals

--- a/Duckling/AmountOfMoney/EN/Corpus.hs
+++ b/Duckling/AmountOfMoney/EN/Corpus.hs
@@ -153,6 +153,8 @@ allExamples = concat
              , "42 L.E"
              , "42 l.e."
              , "42 le"
+             , "42 geneh"
+             , "42 genihat masriya"
              ]
   , examples (simple QAR 42)
              [ "42 QAR"

--- a/Duckling/AmountOfMoney/EN/Corpus.hs
+++ b/Duckling/AmountOfMoney/EN/Corpus.hs
@@ -149,6 +149,10 @@ allExamples = concat
   , examples (simple EGP 42)
              [ "42 EGP"
              , "42 egyptianpound"
+             , "42 LE"
+             , "42 L.E"
+             , "42 l.e."
+             , "42 le"
              ]
   , examples (simple QAR 42)
              [ "42 QAR"

--- a/Duckling/AmountOfMoney/EN/Rules.hs
+++ b/Duckling/AmountOfMoney/EN/Rules.hs
@@ -74,6 +74,15 @@ ruleEgpAbrreviation = Rule
   , prod = \_ -> Just . Token AmountOfMoney $ currencyOnly EGP
   }
 
+ruleEgpArabizi :: Rule
+ruleEgpArabizi = Rule
+  { name = "geneh"
+  , pattern =
+    [ regex "[Gg][eiy]*n[eiy]*h(at)?( m[aiey]?sr[eiy]+a?)?"
+    ]
+  , prod = \_ -> Just . Token AmountOfMoney $ currencyOnly EGP
+  }
+
 ruleRiyals :: Rule
 ruleRiyals = Rule
   { name = "riyals"
@@ -415,6 +424,7 @@ rules =
   , ruleKopiyka
   , ruleOtherPounds
   , ruleEgpAbrreviation
+  , ruleEgpArabizi
   , rulePounds
   , rulePrecision
   , ruleRinggit

--- a/Duckling/AmountOfMoney/EN/Rules.hs
+++ b/Duckling/AmountOfMoney/EN/Rules.hs
@@ -65,6 +65,15 @@ ruleOtherPounds = Rule
       _ -> Nothing
   }
 
+ruleEgpAbrreviation :: Rule
+ruleEgpAbrreviation = Rule
+  { name = "livre égyptienne"
+  , pattern =
+    [ regex "[lL].?[eE].?"
+    ]
+  , prod = \_ -> Just . Token AmountOfMoney $ currencyOnly EGP
+  }
+
 ruleRiyals :: Rule
 ruleRiyals = Rule
   { name = "riyals"
@@ -405,6 +414,7 @@ rules =
   , ruleIntervalDash
   , ruleKopiyka
   , ruleOtherPounds
+  , ruleEgpAbrreviation
   , rulePounds
   , rulePrecision
   , ruleRinggit


### PR DESCRIPTION
These are popular variants/abbreviations of Egyptian pounds.
All these forms are documented on wikipedia (https://en.wikipedia.org/wiki/Egyptian_pound)