### PR TITLE
v0.1.6.1 -> v0.2.0.0

### DIFF
--- a/duckling.cabal
+++ b/duckling.cabal
@@ -6,7 +6,7 @@ cabal-version:       2.2
 -- LICENSE file in the root directory of this source tree.
 
 name:                duckling
-version:             0.1.6.1
+version:             0.2.0.0
 synopsis:            A Haskell library for parsing text into structured data.
 description:
   Duckling is a library for parsing text into structured data.


### PR DESCRIPTION
Necessary major version bump as per PVP: https://pvp.haskell.org/