### PR TITLE
NL: Fix spelling of ‘achttien’ (18)

### DIFF
--- a/Duckling/Numeral/NL/Corpus.hs
+++ b/Duckling/Numeral/NL/Corpus.hs
@@ -65,7 +65,7 @@ allExamples = concat
              ]
   , examples (NumeralValue 18)
              [ "18"
-             , "achtien"
+             , "achttien"
              ]
   , examples (NumeralValue 1.1)
              [ "1,1"

--- a/Duckling/Numeral/NL/Rules.hs
+++ b/Duckling/Numeral/NL/Rules.hs
@@ -223,7 +223,7 @@ zeroNineteenMap = HashMap.fromList
   , ("vijftien", 15)
   , ("zestien", 16)
   , ("zeventien", 17)
-  , ("achtien", 18)
+  , ("achttien", 18)
   , ("negentien", 19)
   ]
 
@@ -231,7 +231,7 @@ ruleInteger :: Rule
 ruleInteger = Rule
   { name = "integer (0..19)"
   , pattern =
-    [ regex "(geen|nul|niks|een|één|twee|drie|vier|vijftien|vijf|zestien|zes|zeventien|zeven|achtien|acht|negentien|negen|tien|elf|twaalf|dertien|veertien)"
+    [ regex "(geen|nul|niks|een|één|twee|drie|vier|vijftien|vijf|zestien|zes|zeventien|zeven|achttien|acht|negentien|negen|tien|elf|twaalf|dertien|veertien)"
     ]
   , prod = \tokens -> case tokens of
       (Token RegexMatch (GroupMatch (match:_)):_) ->

--- a/Duckling/Ordinal/NL/Rules.hs
+++ b/Duckling/Ordinal/NL/Rules.hs
@@ -43,7 +43,7 @@ zeroNineteenMap = HashMap.fromList
   , ("vijftiende", 15)
   , ("zestiende", 16)
   , ("zeventiende", 17)
-  , ("achtiende", 18)
+  , ("achttiende", 18)
   , ("negentiende", 19)
   ]
 
@@ -51,7 +51,7 @@ ruleOrdinalsFirstth :: Rule
 ruleOrdinalsFirstth = Rule
   { name = "ordinals (first..19th)"
   , pattern =
-    [ regex "(eerste|tweede|derde|vierde|vijfde|zeste|zevende|achtste|negende|tiende|elfde|twaalfde|veertiende|vijftiende|zestiende|zeventiende|achtiende|negentiende)"
+    [ regex "(eerste|tweede|derde|vierde|vijfde|zeste|zevende|achtste|negende|tiende|elfde|twaalfde|veertiende|vijftiende|zestiende|zeventiende|achttiende|negentiende)"
     ]
   , prod = \tokens -> case tokens of
       (Token RegexMatch (GroupMatch (match:_)):_) ->


### PR DESCRIPTION
The Dutch numeral and ordinal rules contained a spelling mistake: [‘achttien’](https://en.wiktionary.org/wiki/achttien) (18) was spelt as ‘achtien’ (note the single *t*).

This PR fixes this spelling mistake everywhere in the code base.