### PR TITLE
Bumps tasty upper bound (< 1.5)

### DIFF
--- a/duckling.cabal
+++ b/duckling.cabal
@@ -893,7 +893,7 @@ test-suite duckling-test
                      , text
                      , time
                      , unordered-containers
-                     , tasty                 >= 0.11.1 && < 1.3
+                     , tasty                 >= 0.11.1 && < 1.5
                      , tasty-hunit           >= 0.9.2 && < 1.0
   other-modules:       Duckling.Tests
                      , Duckling.Testing.Asserts


### PR DESCRIPTION
Closes #600 

---

I saw the latest 0.2.0.0 release announcement and decided to try building the project locally.

This compiles successfully with `tasty-1.4.1` and `cabal-install` (cf. the  snippet below if you want to see the full set of packages I compiled/tested with).

<details>
  <summary> cabal.project.freeze </summary>

```
active-repositories: hackage.haskell.org:merge
constraints: any.HUnit ==1.6.2.0,
             any.aeson ==1.5.6.0,
             aeson -bytestring-builder -cffi -developer -fast,
             any.ansi-terminal ==0.11,
             ansi-terminal -example,
             any.ansi-wl-pprint ==0.6.9,
             ansi-wl-pprint -example,
             any.array ==0.5.4.0,
             any.assoc ==1.0.2,
             any.attoparsec ==0.13.2.5,
             attoparsec -developer,
             any.base ==4.14.1.0,
             any.base-compat ==0.11.2,
             any.base-compat-batteries ==0.11.2,
             any.base-orphans ==0.8.4,
             any.bifunctors ==5.5.10,
             bifunctors +semigroups +tagged,
             any.binary ==0.8.8.0,
             any.blaze-builder ==0.4.2.1,
             any.bytestring ==0.10.12.0,
             any.bytestring-builder ==0.10.8.2.0,
             bytestring-builder +bytestring_has_builder,
             any.call-stack ==0.3.0,
             any.case-insensitive ==1.2.1.0,
             any.clock ==0.8.2,
             clock -llvm,
             any.colour ==2.3.5,
             any.comonad ==5.0.8,
             comonad +containers +distributive +indexed-traversable,
             any.constraints ==0.12,
             any.constraints-extras ==0.3.1.0,
             constraints-extras +build-readme,
             any.containers ==0.6.2.1,
             any.data-fix ==0.3.1,
             any.deepseq ==1.4.4.0,
             any.dependent-sum ==0.7.1.0,
             any.directory ==1.3.6.0,
             any.distributive ==0.6.2.1,
             distributive +semigroups +tagged,
             any.dlist ==1.0,
             dlist -werror,
             any.extensible-exceptions ==0.1.1.4,
             any.extra ==1.7.9,
             any.filepath ==1.4.2.1,
             any.generic-deriving ==1.14,
             generic-deriving +base-4-9,
             any.ghc-boot-th ==8.10.4,
             any.ghc-prim ==0.6.1,
             any.happy ==1.20.0,
             any.hashable ==1.3.1.0,
             hashable +integer-gmp,
             any.haskell-src-exts ==1.23.1,
             any.hsc2hs ==0.68.7,
             hsc2hs -in-ghc-tree,
             any.indexed-traversable ==0.1.1,
             any.integer-gmp ==1.0.3.0,
             any.integer-logarithms ==1.0.3.1,
             integer-logarithms -check-bounds +integer-gmp,
             any.io-streams ==1.5.2.0,
             io-streams +network -nointeractivetests +zlib,
             any.io-streams-haproxy ==1.0.1.0,
             any.lifted-base ==0.2.3.12,
             any.monad-control ==1.0.2.3,
             any.mtl ==2.2.2,
             any.network ==3.1.2.1,
             network -devel,
             any.network-uri ==2.6.4.1,
             any.old-locale ==1.0.0.7,
             any.optparse-applicative ==0.16.1.0,
             optparse-applicative +process,
             any.parsec ==3.1.14.0,
             any.pretty ==1.1.3.6,
             any.primitive ==0.7.1.0,
             any.process ==1.6.9.0,
             any.random ==1.2.0,
             any.readable ==0.3.1,
             any.regex-base ==0.94.0.1,
             any.regex-pcre ==0.95.0.0,
             any.regex-posix ==0.96.0.0,
             regex-posix -_regex-posix-clib,
             any.rts ==1.0,
             any.scientific ==0.3.6.2,
             scientific -bytestring-builder -integer-simple,
             any.semigroups ==0.19.1,
             semigroups +binary +bytestring -bytestring-builder +containers +deepseq +hashable +tagged +template-haskell +text +transformers +unordered-containers,
             any.snap-core ==1.0.4.2,
             snap-core -debug +network-uri -portable,
             any.snap-server ==1.1.2.0,
             snap-server -build-pong -build-testserver -debug -openssl -portable,
             any.some ==1.0.2,
             some +newtype-unsafe,
             any.splitmix ==0.1.0.3,
             splitmix -optimised-mixer,
             any.stm ==2.5.0.0,
             any.strict ==0.4.0.1,
             strict +assoc,
             any.tagged ==0.8.6.1,
             tagged +deepseq +transformers,
             any.tasty ==1.4.1,
             tasty +clock +unix,
             any.tasty-hunit ==0.10.0.3,
             any.template-haskell ==2.16.0.0,
             any.text ==1.2.4.1,
             any.text-show ==3.9,
             text-show +base-4-9 +new-functor-classes +template-haskell-2-11,
             any.th-abstraction ==0.4.2.0,
             any.th-compat ==0.1.2,
             any.th-lift ==0.8.2,
             any.these ==1.1.1.1,
             these +assoc,
             any.time ==1.9.3,
             any.time-compat ==1.9.5,
             time-compat -old-locale,
             any.timezone-olson ==0.2.0,
             any.timezone-series ==0.1.9,
             any.transformers ==0.5.6.2,
             any.transformers-base ==0.4.5.2,
             transformers-base +orphaninstances,
             any.transformers-compat ==0.6.6,
             transformers-compat -five +five-three -four +generic-deriving +mtl -three -two,
             any.type-equality ==1,
             any.unbounded-delays ==0.1.1.1,
             any.unix ==2.7.2.2,
             any.unix-compat ==0.5.3,
             unix-compat -old-time,
             any.unordered-containers ==0.2.13.0,
             unordered-containers -debug,
             any.uuid-types ==1.0.4,
             any.vector ==0.12.3.0,
             vector +boundschecks -internalchecks -unsafechecks -wall,
             any.wcwidth ==0.0.2,
             wcwidth -cli +split-base,
             any.zlib ==0.6.2.3,
             any.zlib-bindings ==0.1.1.5
index-state: hackage.haskell.org 2021-04-18T19:08:29Z
```

</details>

The test suite fails with the following error:

```
    Numeral Tests
      AF Tests
        Corpus Tests:              FAIL
          tests/Duckling/Testing/Asserts.hs:90:
          empty result on "agt"
```

...but from what I can tell by the last few CI runs some corpus test errors are not unexpected so I figure this _probably_ isn't a regression.

---

I avoided messing with the Stackage snapshot since that seemed out-of-scope, but I could rework this PR (or open another) to update it to the latest LTS resolver and/or add a Stackage Nightly resolver as well.