### PR TITLE
Updated README to fix Duckling logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Duckling Logo](https://github.com/facebook/duckling/raw/master/logo.png)
+![Duckling Logo](https://github.com/facebook/duckling/raw/main/logo.png)
 
 # Duckling [![Build Status](https://travis-ci.org/facebook/duckling.svg?branch=master)](https://travis-ci.org/facebook/duckling)
 Duckling is a Haskell library that parses text into structured data.


### PR DESCRIPTION
Fix logo path wich still using 'master' to reference main branch