### PR TITLE
Fix image link, add link to license & linting (fix-cla)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,40 +1,50 @@
-![Duckling Logo](https://github.com/facebook/duckling/raw/master/logo.png)
+![Duckling Logo](https://github.com/facebook/duckling/raw/main/logo.png)
 
 # Duckling [![Build Status](https://travis-ci.org/facebook/duckling.svg?branch=master)](https://travis-ci.org/facebook/duckling)
+
 Duckling is a Haskell library that parses text into structured data.
 
-```
+```bash
 "the first Tuesday of October"
 => {"value":"2017-10-03T00:00:00.000-07:00","grain":"day"}
 ```
 
 ## Requirements
+
 A Haskell environment is required. We recommend using
 [stack](https://haskell-lang.org/get-started).
 
 On Linux and MacOS you'll need to install PCRE development headers.
 On Linux, use your package manager to install them.
 On MacOS, the easiest way to install them is with [Homebrew](https://brew.sh/):
-```
+
+```bash
 brew install pcre
 ```
+
 If that doesn't help, try running `brew doctor` and fix
 the issues it finds.
 
 ## Quickstart
+
 To compile and run the binary:
+
+```bash
+stack build
+stack exec duckling-example-exe
 ```
-$ stack build
-$ stack exec duckling-example-exe
-```
+
 The first time you run it, it will download all required packages.
 
 This runs a basic HTTP server. Example request:
+
+```bash
+curl -XPOST http://0.0.0.0:8000/parse --data 'locale=en_GB&text=tomorrow at eight'
 ```
-$ curl -XPOST http://0.0.0.0:8000/parse --data 'locale=en_GB&text=tomorrow at eight'
-```
+
 In the example application, all dimensions are enabled by default. Provide the parameter `dims` to specify which ones you want. Examples:
-```
+
+```bash
 Identify credit card numbers only:
 $ curl -XPOST http://0.0.0.0:8000/parse --data 'locale=en_US&text="4111-1111-1111-1111"&dims="["credit-card-number"]"'
 If you want multiple dimensions, comma-separate them in the array:
@@ -46,6 +56,7 @@ project.
 If your backend doesn't run Haskell or if you don't want to spin your own Duckling server, you can directly use [wit.ai](https://wit.ai)'s built-in entities.
 
 ## Supported dimensions
+
 Duckling supports many languages, but most don't support all dimensions yet
 (**we need your help!**).
 Please look into [this directory](https://github.com/facebook/duckling/blob/master/Duckling/Dimensions) for language-specific support.
@@ -69,9 +80,11 @@ Please look into [this directory](https://github.com/facebook/duckling/blob/mast
 [Custom dimensions](https://github.com/facebook/duckling/blob/master/exe/CustomDimensionExample.hs) are also supported.
 
 ## Extending Duckling
+
 To regenerate the classifiers and run the test suite:
-```
-$ stack build :duckling-regen-exe && stack exec duckling-regen-exe && stack test
+
+```bash
+stack build :duckling-regen-exe && stack exec duckling-regen-exe && stack test
 ```
 
 It's important to regenerate the classifiers after updating the code and before
@@ -79,17 +92,23 @@ running the test suite.
 
 To extend Duckling's support for a dimension in a given language, typically 4
 files need to be updated:
+
 * `Duckling/<Dimension>/<Lang>/Rules.hs`
+
 * `Duckling/<Dimension>/<Lang>/Corpus.hs`
+
 * `Duckling/Dimensions/<Lang>.hs` (if not already present in `Duckling/Dimensions/Common.hs`)
+
 * `Duckling/Rules/<Lang>.hs`
 
 To add a new language:
+
 * Make sure that the language code used follows the [ISO-639-1 standard](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes).
 * The first dimension to implement is `Numeral`.
 * Follow [this example](https://github.com/facebook/duckling/commit/24d3f199768be970149412c95b1c1bf5d76f8240).
 
 To add a new locale:
+
 * There should be a need for diverging rules between the locale and the language.
 * Make sure that the locale code is a valid [ISO3166 alpha2 country code](https://www.iso.org/obp/ui/#search/code/).
 * Follow [this example](https://github.com/facebook/duckling/commit/1ab5f447d2635fe6d48887a501d333a52adff5b9).
@@ -105,7 +124,8 @@ shouldn't) parse. The reference time for the corpus is Tuesday Feb 12, 2013 at
 4:30am.
 
 `Duckling.Debug` provides a few debugging tools:
-```
+
+```bash
 $ stack repl --no-load
 > :l Duckling.Debug
 > debug (makeLocale EN $ Just US) "in two minutes" [Seal Time]
@@ -120,4 +140,5 @@ in|within|after <duration> (in two minutes)
 ```
 
 ## License
-Duckling is BSD-licensed.
+
+Duckling is [BSD-licensed](LICENSE).


### PR DESCRIPTION
This is documentation changes.
 _Note: This version is misname cla error_

- [x] Fix image link from master <https://github.com/facebook/duckling/raw/master/logo.png> to <https://github.com/facebook/duckling/raw/main/logo.png>

- [x] Add language to code fences
- [x] Add link to LICENSE file

