### PR TITLE
Numeral/DE: fix eine not being recognized

### DIFF
--- a/Duckling/Numeral/DE/Corpus.hs
+++ b/Duckling/Numeral/DE/Corpus.hs
@@ -140,6 +140,7 @@ allExamples = concat
              [ "1.416,15"
              ]
   , examples (NumeralValue 1000000.0)
-             [ "1.000.000,00"
+             [ "1.000.000,00",
+               "eine million"
              ]
   ]

--- a/Duckling/Numeral/DE/Rules.hs
+++ b/Duckling/Numeral/DE/Rules.hs
@@ -255,7 +255,7 @@ ruleZeroToNineteen :: Rule
 ruleZeroToNineteen = Rule
   { name = "integer (0..19)"
   , pattern =
-    [ regex "(keine[rn]|keine?s?|null|nichts|eins?(er)?|zwei|dreizehn|drei|vierzehn|vier|fünfzehn|fünf|sechzehn|sechs|siebzehn|sieben|achtzehn|acht|neunzehn|neun|elf|zwölf)"
+    [ regex "(keine[rn]|keine?s?|null|nichts|eins?(er?)?|zwei|dreizehn|drei|vierzehn|vier|fünfzehn|fünf|sechzehn|sechs|siebzehn|sieben|achtzehn|acht|neunzehn|neun|elf|zwölf)"
     ]
   , prod = \tokens -> case tokens of
       (Token RegexMatch (GroupMatch (match:_)):_) ->


### PR DESCRIPTION
Numbers like "eine million" "eine milliarde" were not recognized correctly.