### PR TITLE
recognise Swiss thousand separator in Numerals

### DIFF
--- a/Duckling/Numeral/DE/Corpus.hs
+++ b/Duckling/Numeral/DE/Corpus.hs
@@ -156,4 +156,8 @@ allExamples = concat
   , examples (NumeralValue 2771090092000000.0)
              [ "zwei billiarden siebenhunderteinundsiebzig billionen neunzig milliarden zweiundneunzig millionen"
              ]
+  , examples (NumeralValue 100000.0)
+             [ "100'000",
+               "100'000.00"
+             ]
   ]

--- a/Duckling/Numeral/DE/Corpus.hs
+++ b/Duckling/Numeral/DE/Corpus.hs
@@ -157,7 +157,6 @@ allExamples = concat
              [ "zwei billiarden siebenhunderteinundsiebzig billionen neunzig milliarden zweiundneunzig millionen"
              ]
   , examples (NumeralValue 100000.0)
-             [ "100'000",
-               "100'000.00"
+             [ "100'000"
              ]
   ]

--- a/Duckling/Numeral/DE/Rules.hs
+++ b/Duckling/Numeral/DE/Rules.hs
@@ -51,6 +51,19 @@ ruleFew = Rule
   , prod = \_ -> integer 3
   }
 
+ruleDecimalWithSwissThousandsSeparator :: Rule
+ruleDecimalWithSwissThousandsSeparator = Rule
+  { name = "decimal with thousands separator"
+  , pattern =
+    [ regex "(\\d+(\\'\\d\\d\\d)+\\,\\d+)"
+    ]
+  , prod = \tokens -> case tokens of
+      (Token RegexMatch (GroupMatch (match:_)):
+       _) -> let fmt = Text.replace "," "." $ Text.replace "." Text.empty match
+        in parseDouble fmt >>= double
+      _ -> Nothing
+  }
+
 ruleDecimalWithThousandsSeparator :: Rule
 ruleDecimalWithThousandsSeparator = Rule
   { name = "decimal with thousands separator"
@@ -203,6 +216,18 @@ ruleNumeralDotNumeral = Rule
       _ -> Nothing
   }
 
+ruleIntegerWithSwissThousandsSeparator :: Rule
+ruleIntegerWithSwissThousandsSeparator = Rule
+  { name = "integer with thousands separator ."
+  , pattern =
+    [ regex "(\\d{1,3}(\\'\\d\\d\\d){1,5})"
+    ]
+  , prod = \tokens -> case tokens of
+      (Token RegexMatch (GroupMatch (match:_)):_) ->
+        parseDouble (Text.replace "'" Text.empty match) >>= double
+      _ -> Nothing
+  }
+
 ruleIntegerWithThousandsSeparator :: Rule
 ruleIntegerWithThousandsSeparator = Rule
   { name = "integer with thousands separator ."
@@ -231,9 +256,11 @@ rules =
   [ ruleCouple
   , ruleDecimalNumeral
   , ruleDecimalWithThousandsSeparator
+  , ruleDecimalWithSwissThousandsSeparator
   , ruleDozen
   , ruleFew
   , ruleIntegerWithThousandsSeparator
+  , ruleIntegerWithSwissThousandsSeparator
   , ruleIntersect
   , ruleMultiply
   , ruleNumeralDotNumeral


### PR DESCRIPTION
In Switzerland, 10,000 is written usually as 10'000. We added this separator to the Rules in the DE Numerals Rules. 