### PR TITLE
Feat/ol 96792

### DIFF
--- a/Duckling/Numeral/EN/Corpus.hs
+++ b/Duckling/Numeral/EN/Corpus.hs
@@ -188,4 +188,9 @@ allExamples = concat
              [ "forty-five (45)"
              , "45 (forty five)"
              ]
+  , examples (NumeralValue 2)
+             [ "Number2"
+             , "Number2."
+             , "number2!"
+             ]
   ]

--- a/Duckling/Numeral/EN/Rules.hs
+++ b/Duckling/Numeral/EN/Rules.hs
@@ -352,6 +352,18 @@ ruleLegalParentheses = Rule
     _ -> Nothing
   }
 
+-- number1., Number1
+ruleNumberTextInteger :: Rule
+ruleNumberTextInteger = Rule
+  { name = "Number<integer>"
+  , pattern =
+    [ regex "(?:N|n)umber(\\d+)[.,!]*"
+    ]
+  , prod = \tokens -> case tokens of
+      (Token RegexMatch (GroupMatch (match:_)):_) -> parseDecimal True match
+      _ -> Nothing
+  }
+
 rules :: [Rule]
 rules =
   [ ruleToNineteen
@@ -371,4 +383,5 @@ rules =
   , ruleMultiply
   , ruleDozen
   , ruleLegalParentheses
+  , ruleNumberTextInteger
   ]

--- a/Duckling/Time/EN/Corpus.hs
+++ b/Duckling/Time/EN/Corpus.hs
@@ -1954,6 +1954,6 @@ allExamples = concat
              , "1 Mon  Feb 18 13:30" ]
   , examples (datetime (2013, 2, 19, 1, 30, 0) Minute)
              [ "#1 Tue, February 19 at 01:30 am"
-             , "1 Tues Feb at 19 1:30"
+             , "1 Tues Feb 19 at 1:30"
              , "1. Tuesday Feb 19 1:30am" ]
   ]


### PR DESCRIPTION
Fix the bug in Duckling that returned only one result when users did not define 'am/pm'. Now, if the candidate types the selection without 'am/pm', Duckling returns two results - one for the AM time and the other for the PM time.