### PR TITLE
ref: add zwo as alternative for 2

### DIFF
--- a/Duckling/Numeral/DE/Corpus.hs
+++ b/Duckling/Numeral/DE/Corpus.hs
@@ -36,6 +36,11 @@ allExamples = concat
              , "Eine"
              , "einen"
              ]
+  , examples (NumeralValue 2)
+             [ "2"
+             , "Zwei"
+             , "Zwo"
+             ]
   , examples (NumeralValue 3)
              [ "3"
              , "Drei"

--- a/Duckling/Numeral/DE/NumParser.hs
+++ b/Duckling/Numeral/DE/NumParser.hs
@@ -103,6 +103,10 @@ two =
     , times10 = [assign 20 "zwanzig"]
     }
 
+two_alternative :: NumItem
+two_alternative = defaultNumItem 2 "zwo"
+
+
 three :: NumItem
 three =
   (defaultNumItem 3 "drei")
@@ -139,7 +143,7 @@ nine :: NumItem
 nine = defaultNumItem 9 "neun"
 
 digitLexicon :: [NumItem]
-digitLexicon = [one, two, three, four, five, six, seven, eight, nine]
+digitLexicon = [one, two_alternative, two, three, four, five, six, seven, eight, nine]
 
 from1to9 :: NumParser
 from1to9 = foldr ((<|>) . base) empty digitLexicon

--- a/Duckling/Numeral/DE/Rules.hs
+++ b/Duckling/Numeral/DE/Rules.hs
@@ -76,6 +76,15 @@ ruleDecimalNumeral = Rule
       _ -> Nothing
   }
 
+ruleTwo :: Rule
+ruleTwo = Rule
+  { name = "integer 2"
+  , pattern =
+    [ regex "(zwei|zwo)"
+    ]
+  , prod = \_ -> integer 2
+  }
+  
 ruleNumeralsUnd :: Rule
 ruleNumeralsUnd = Rule
   { name = "numbers und"
@@ -218,7 +227,7 @@ ruleIntegerWithThousandsSeparator = Rule
 ruleAllNumeralWords :: Rule
 ruleAllNumeralWords = Rule
   { name = "simple and complex numerals written as one word"
-  , pattern = [regex "(ein|zwei|drei|vier|fünf|sech|sieb|acht|neun|zehn|elf|zwölf|hundert|tausend)?([^\\s]+)?(eine[m|n|r|s]?|eins?|zwei|drei|vier|fünf|sechs|sieben|acht|neun|zehn|elf|zwölf|[s|ß|z]ig|hundert|tausend)"]
+  , pattern = [regex "(ein|zwei|zwo|drei|vier|fünf|sech|sieb|acht|neun|zehn|elf|zwölf|hundert|tausend)?([^\\s]+)?(eine[m|n|r|s]?|eins?|zwei|drei|vier|fünf|sechs|sieben|acht|neun|zehn|elf|zwölf|[s|ß|z]ig|hundert|tausend)"]
   , prod = \tokens -> case tokens of
       (Token RegexMatch (GroupMatch matches) : _) ->
         (parseNumeral $ concat $ Text.unpack . Text.toLower <$> matches)


### PR DESCRIPTION
We have noticed that often in spoken german, people are using `zwo` as an alternative to `zwei`. I tried to add in the german NumParser and corresponding rules. let me know if this is okay or i should make some changes to get it working. 

Thanks