### PR TITLE
Update Swedish date corpus

### DIFF
--- a/Duckling/Time/SV/Corpus.hs
+++ b/Duckling/Time/SV/Corpus.hs
@@ -105,6 +105,14 @@ allExamples = concat
              , "februari 15"
              , "15-02"
              , "15/02"
+             , "15/2"
+             , "den 15-02"
+             , "den 15/02"
+             , "den 15/2"
+             ]
+  , examples (datetime (2013, 2, 4, 0, 0, 0) Day)
+             [ "4/2"
+             , "den 4/2"
              ]
   , examples (datetime (2013, 8, 8, 0, 0, 0) Day)
              [ "8 Aug"


### PR DESCRIPTION
Added some more rules to the Swedish corpus for dates. I believe the correct rules are already in place. Added some more rules to handle missing zeros in the month part of dd/mm (for example 15/2, 15/02, 4/2, and more).