### PR TITLE
Disable Windows build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macOS-latest, windows-latest]
+        os: [ubuntu-latest, macOS-latest]
         stack: ["2.5.1"]
         ghc: ["8.6.5", "8.8.4", "8.10.3", "9.0.1"]
 


### PR DESCRIPTION
The current stack version is not compatible with the latest Windows versions and can be temporarily disabled.