### PR TITLE
add optional 's' to 'donnerstag' in DE time rules

### DIFF
--- a/Duckling/Time/DE/Rules.hs
+++ b/Duckling/Time/DE/Rules.hs
@@ -52,7 +52,7 @@ ruleDaysOfWeek = mkRuleDaysOfWeek
   [ ( "Montag"    , "montags?|mo\\.?"              )
   , ( "Dienstag"  , "die?nstags?|di\\.?"           )
   , ( "Mittwoch"  , "mittwochs?|mi\\.?"            )
-  , ( "Donnerstag", "donn?erstag|do\\.?"           )
+  , ( "Donnerstag", "donn?erstags?|do\\.?"         )
   , ( "Freitag"   , "freitags?|fr\\.?"             )
   , ( "Samstag"   , "samstags?|sonnabends?|sa\\.?" )
   , ( "Sonntag"   , "sonntags?|so\\."             )


### PR DESCRIPTION
summary: as title